### PR TITLE
fix: limit the size of validation message queue

### DIFF
--- a/splunktaucclib/rest_handler/endpoint/validator.py
+++ b/splunktaucclib/rest_handler/endpoint/validator.py
@@ -41,9 +41,10 @@ class Validator(object):
     Base class of validators.
     """
 
-    def __init__(self):
+    def __init__(self, max_size=20):
         # Validation error message queue
         self._msgs = []
+        self._max_queue_size = max_size
 
     def validate(self, value, data):
         """
@@ -78,6 +79,8 @@ class Validator(object):
             self._msgs.insert(0, msg)
         else:
             self._msgs.append(msg)
+        if len(self._msgs) > self._max_queue_size:
+            self._msgs = self._msgs[:self._max_queue_size]
 
 
 class ValidationFailed(Exception):

--- a/splunktaucclib/rest_handler/endpoint/validator.py
+++ b/splunktaucclib/rest_handler/endpoint/validator.py
@@ -13,6 +13,7 @@ import sys
 from builtins import object
 import re
 import json
+import warnings
 from inspect import isfunction
 
 
@@ -41,10 +42,8 @@ class Validator(object):
     Base class of validators.
     """
 
-    def __init__(self, max_size=20):
-        # Validation error message queue
-        self._msgs = []
-        self._max_queue_size = max_size
+    def __init__(self):
+        self._msg = ""
 
     def validate(self, value, data):
         """
@@ -65,22 +64,22 @@ class Validator(object):
 
         :return:
         """
-        return self._msgs[0] if self._msgs else "Invalid input value"
+        return self._msg if self._msg else "Invalid input value"
 
-    def put_msg(self, msg, high_priority=False):
+    def put_msg(self, msg, *args, **kwargs):
         """
         Put message content into pool.
 
         :param msg: error message content
-        :param high_priority: is this message with high priority
         :return:
         """
-        if high_priority:
-            self._msgs.insert(0, msg)
-        else:
-            self._msgs.append(msg)
-        if len(self._msgs) > self._max_queue_size:
-            self._msgs = self._msgs[:self._max_queue_size]
+        if args or "high_priority" in kwargs:
+            warnings.warn(
+                "`high_priority` arg is deprecated and at a time a single message string is kept in memory."
+                " The last message passed to `put_msg` is returned by `msg` property.",
+                DeprecationWarning
+            )
+        self._msg = msg
 
 
 class ValidationFailed(Exception):


### PR DESCRIPTION
**Issue:** If in `restmap.conf` rest handler is set to be persistent (which is the default in UCC rest handlers) then the list of messages will keep on increasing and fill up memory until the rest handler gets refreshed.

**Note:** Even with persistent handlers, this can only cause issue if the user requests the endpoint continuously.

**Fix:** Limit the length of the validation message list