### PR TITLE
Migration from httplib2 to requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.30.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,17 +70,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "httplib2"
-version = "0.20.2"
-description = "A comprehensive HTTP client library."
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
-
-[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -151,7 +140,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -250,7 +239,7 @@ python-versions = "*"
 
 [[package]]
 name = "splunktalib"
-version = "2.2.6"
+version = "3.0.0b1"
 description = "Supporting library for Splunk Add-ons"
 category = "main"
 optional = false
@@ -258,7 +247,7 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 defusedxml = ">=0,<1"
-httplib2 = ">=0,<1"
+requests = ">=2.26.0,<3.0.0"
 sortedcontainers = ">=2,<3"
 
 [[package]]
@@ -313,7 +302,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2e356bc476057ee77b1135a2b4eabba393c726b52af4497bf2309dd5cb68ca9e"
+content-hash = "e046fbe18cc7c4b43039236600e9f874b61d9907087433ab9b7173338e2f60db"
 
 [metadata.files]
 atomicwrites = [
@@ -389,10 +378,6 @@ defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-httplib2 = [
-    {file = "httplib2-0.20.2-py3-none-any.whl", hash = "sha256:6b937120e7d786482881b44b8eec230c1ee1c5c1d06bce8cc865f25abbbf713b"},
-    {file = "httplib2-0.20.2.tar.gz", hash = "sha256:e404681d2fbcec7506bcb52c503f2b021e95bee0ef7d01e5c221468a2406d8dc"},
-]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -450,8 +435,8 @@ splunk-sdk = [
     {file = "splunk-sdk-1.6.18.tar.gz", hash = "sha256:edc0959786f5dcab225ba98633c310dbf7584977849f6c2152a0e5090b5e2561"},
 ]
 splunktalib = [
-    {file = "splunktalib-2.2.6-py3-none-any.whl", hash = "sha256:bba70ac7407cdedcb45437cb152ac0e43aae16b978031308e6bec548d3543119"},
-    {file = "splunktalib-2.2.6.tar.gz", hash = "sha256:8d58d697a842319b4c675557b0cc4a9c68e8d909389a98ed240e2bb4ff358d31"},
+    {file = "splunktalib-3.0.0b1-py3-none-any.whl", hash = "sha256:a22a5bf7e5451b94acc491a9d5c62c01778896e9705b481c825a7513b3634a4d"},
+    {file = "splunktalib-3.0.0b1.tar.gz", hash = "sha256:141341f522641d9e24362445daeb23aef502b1fbf4a3bb90ae196cfd0b6c64fb"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,7 +220,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "solnlib"
-version = "4.5.0"
+version = "4.6.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 category = "main"
 optional = false
@@ -439,8 +439,8 @@ requests = [
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
 solnlib = [
-    {file = "solnlib-4.5.0-py3-none-any.whl", hash = "sha256:7765174e4767585992a38ed21ae5f5107481fc767b892f2be231cce0e2baa5cc"},
-    {file = "solnlib-4.5.0.tar.gz", hash = "sha256:d16d5a4614d8a0dab666deb3b8de4e464d543f20ddb8165855890d3b6f264c6c"},
+    {file = "solnlib-4.6.0-py3-none-any.whl", hash = "sha256:12f9efa1c4545919630d3a7353dc1e8ee4e21bddf6311b359be84c597be8f1f7"},
+    {file = "solnlib-4.6.0.tar.gz", hash = "sha256:ec4668384b74c57aa2b25eb93cf3e130ce8fa6d9ff2685c0e3ae38dd9bb72099"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -156,6 +156,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pytest"
 version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
@@ -305,7 +313,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6a3760090298e4c62d7485af9f96559ad5d83a016e1b4cc9d629f610dcdd3fff"
+content-hash = "2e356bc476057ee77b1135a2b4eabba393c726b52af4497bf2309dd5cb68ca9e"
 
 [metadata.files]
 atomicwrites = [
@@ -412,6 +420,11 @@ py = [
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pysocks = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -250,7 +250,7 @@ python-versions = "*"
 
 [[package]]
 name = "splunktalib"
-version = "2.2.5"
+version = "2.2.6"
 description = "Supporting library for Splunk Add-ons"
 category = "main"
 optional = false
@@ -450,8 +450,8 @@ splunk-sdk = [
     {file = "splunk-sdk-1.6.18.tar.gz", hash = "sha256:edc0959786f5dcab225ba98633c310dbf7584977849f6c2152a0e5090b5e2561"},
 ]
 splunktalib = [
-    {file = "splunktalib-2.2.5-py3-none-any.whl", hash = "sha256:39c0824d4e8df1f535e4425740290e6fbc448268960b3012d9639887b9eaf45e"},
-    {file = "splunktalib-2.2.5.tar.gz", hash = "sha256:423d6b59c5d22bf5acf110a21407fb39b4c50e55b0459e8457225df244b33411"},
+    {file = "splunktalib-2.2.6-py3-none-any.whl", hash = "sha256:bba70ac7407cdedcb45437cb152ac0e43aae16b978031308e6bec548d3543119"},
+    {file = "splunktalib-2.2.6.tar.gz", hash = "sha256:8d58d697a842319b4c675557b0cc4a9c68e8d909389a98ed240e2bb4ff358d31"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,7 +220,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "solnlib"
-version = "4.4.1"
+version = "4.5.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 category = "main"
 optional = false
@@ -439,8 +439,8 @@ requests = [
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
 solnlib = [
-    {file = "solnlib-4.4.1-py3-none-any.whl", hash = "sha256:c15fc4946b5a7bbb5328bfa510cadee6d586d71416302196ecd1ee9292f60044"},
-    {file = "solnlib-4.4.1.tar.gz", hash = "sha256:e857bf54025b9f47b7400779833a320bf0fea774a4ae78b65f9980526dc203ef"},
+    {file = "solnlib-4.5.0-py3-none-any.whl", hash = "sha256:7765174e4767585992a38ed21ae5f5107481fc767b892f2be231cce0e2baa5cc"},
+    {file = "solnlib-4.5.0.tar.gz", hash = "sha256:d16d5a4614d8a0dab666deb3b8de4e464d543f20ddb8165855890d3b6f264c6c"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ python = "^3.7"
 solnlib = "^4.0.0"
 splunk-sdk = "^1.6.16"
 splunktalib = "^2.0.0"
+requests = "^2.26.0"
+PySocks = "^1.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "APACHE-2.0"
 python = "^3.7"
 solnlib = "^4.0.0"
 splunk-sdk = "^1.6.16"
-splunktalib = "^2.0.0"
+splunktalib = "^3.0.0b1"
 requests = "^2.26.0"
 PySocks = "^1.7.1"
 

--- a/splunktaucclib/config.py
+++ b/splunktaucclib/config.py
@@ -356,8 +356,8 @@ class Config:
 
     def try_fix_corrupted_json(self, corrupted_json, value_err):
         """
-        When L3 (one of our customers) was testing, they encountered a bug that 'access_token_encrypted'
-        or 'refresh_token' got corrupted when it was saved in the conf file
+        A bug was encountered that 'access_token_encrypted' or 'refresh_token'
+        got corrupted when it was saved in the conf file
         (because of the way how we save encrypted data).
         """
         # value_err.message is in this format:

--- a/splunktaucclib/config.py
+++ b/splunktaucclib/config.py
@@ -127,22 +127,20 @@ class Config:
             retries = 4
             waiting_time = [1, 2, 2]
             for retry in range(retries):
-                resp, cont = splunkd_request(
+                resp = splunkd_request(
                     splunkd_uri=self.make_uri(ep_id),
                     session_key=self.session_key,
                     data=data,
                     retry=3,
                 )
 
-                if resp is None or resp.status != 200:
-                    msg = 'Fail to load endpoint "{ep_id}" - {err}' "".format(
-                        ep_id=ep_id, err=code_to_msg(resp, cont) if resp else cont
-                    )
+                if resp is None or resp.status_code != 200:
+                    msg = f'Fail to load endpoint "{ep_id}" - {code_to_msg(resp)}'
                     log(msg, level=logging.ERROR, need_tb=True)
                     raise ConfigException(msg)
 
                 try:
-                    ret[ep_id] = self._parse_content(ep_id, cont)
+                    ret[ep_id] = self._parse_content(ep_id, resp.text)
                 except ConfigException as exc:
                     log(exc, level=logging.WARNING, need_tb=True)
                     if retry < retries - 1:
@@ -206,22 +204,15 @@ class Config:
                 continue
             item_uri = self.make_uri(endpoint_id, item_name=item_name)
 
-            resp, cont = splunkd_request(
+            resp = splunkd_request(
                 splunkd_uri=item_uri,
                 session_key=self.session_key,
                 data=post_data,
                 method="POST",
                 retry=3,
             )
-            if resp is None or resp.status not in (200, 201):
-                msg = (
-                    'Fail to update item "{item}" in endpoint "{ep_id}"'
-                    " - {err}".format(
-                        ep_id=endpoint_id,
-                        item=item_name,
-                        err=code_to_msg(resp, cont) if resp else cont,
-                    )
-                )
+            if resp is None or resp.status_code not in (200, 201):
+                msg = f'Fail to update item "{item_name}" in endpoint "{endpoint_id}" - {code_to_msg(resp)}'
                 log(msg, level=logging.ERROR)
                 if raise_if_failed:
                     raise ConfigException(msg)
@@ -365,7 +356,8 @@ class Config:
 
     def try_fix_corrupted_json(self, corrupted_json, value_err):
         """
-        When L3 (one of our customers) was testing, they encountered a bug that 'access_token_encrypted' or 'refresh_token' got corrupted when it was saved in the conf file
+        When L3 (one of our customers) was testing, they encountered a bug that 'access_token_encrypted'
+        or 'refresh_token' got corrupted when it was saved in the conf file
         (because of the way how we save encrypted data).
         """
         # value_err.message is in this format:

--- a/splunktaucclib/rest_handler/base.py
+++ b/splunktaucclib/rest_handler/base.py
@@ -21,7 +21,6 @@ import copy
 import itertools
 import json
 import logging
-import sys
 from inspect import ismethod
 from os import path as op
 
@@ -68,15 +67,15 @@ def user_caps(mgmt_uri, session_key):
     """
     url = mgmt_uri + "/services/authentication/current-context"
 
-    resp, cont = splunkd_request(
+    resp = splunkd_request(
         url, session_key, method="GET", data={"output_mode": "json"}, retry=3
     )
     if resp is None:
         RH_Err.ctl(500, logging.ERROR, "Fail to get capabilities of sessioned user")
-    elif resp.status not in (200, "200"):
-        RH_Err.ctl(resp.status, logging.ERROR, cont)
+    elif resp.status_code not in (200, "200"):
+        RH_Err.ctl(resp.status_code, logging.ERROR, resp.text)
 
-    cont = json.loads(cont)
+    cont = resp.json()
     caps = cont["entry"][0]["content"]["capabilities"]
     return set(caps)
 
@@ -288,7 +287,7 @@ class BaseRestHandler(admin.MConfigHandler):
     def handleCreate(self, confInfo):
         try:
             self.get(self.callerArgs.id)
-        except:
+        except Exception:
             pass
         else:
             RH_Err.ctl(

--- a/splunktaucclib/rest_handler/base.py
+++ b/splunktaucclib/rest_handler/base.py
@@ -72,7 +72,7 @@ def user_caps(mgmt_uri, session_key):
     )
     if resp is None:
         RH_Err.ctl(500, logging.ERROR, "Fail to get capabilities of sessioned user")
-    elif resp.status_code not in (200, "200"):
+    elif resp.status_code != 200:
         RH_Err.ctl(resp.status_code, logging.ERROR, resp.text)
 
     cont = resp.json()

--- a/splunktaucclib/rest_handler/teardown.py
+++ b/splunktaucclib/rest_handler/teardown.py
@@ -99,7 +99,7 @@ class TeardownHandler(base.BaseRestHandler):
 
     def clean(self, endpoint):
         url = self.make_uri(endpoint) + "?count=-1"
-        resp, cont = splunkd_request(
+        resp = splunkd_request(
             url,
             self.getSessionKey(),
             method="GET",
@@ -109,10 +109,10 @@ class TeardownHandler(base.BaseRestHandler):
 
         if resp is None:
             return {url: "Unknown reason"}
-        if resp.status != 200:
-            return {url: self.convertErrMsg(cont)}
+        if resp.status_code != 200:
+            return {url: self.convertErrMsg(resp.text)}
 
-        cont = json.loads(cont)
+        cont = resp.json()
         ents = [ent["name"] for ent in cont.get("entry", [])]
         errs = {}
         for ent in ents:
@@ -120,7 +120,7 @@ class TeardownHandler(base.BaseRestHandler):
             if not self.distinguish(endpoint, ent, **args):
                 continue
             url_ent = self.make_uri(endpoint, entry=ent)
-            resp, cont = splunkd_request(
+            resp = splunkd_request(
                 url_ent,
                 self.getSessionKey(),
                 method="DELETE",
@@ -130,7 +130,7 @@ class TeardownHandler(base.BaseRestHandler):
 
             if resp is None:
                 errs[url_ent] = "Unknown reason"
-            if resp.status != 200:
+            if resp.status_code != 200:
                 errs[url_ent] = self.convertErrMsg(cont)
         return errs
 

--- a/splunktaucclib/rest_handler/util.py
+++ b/splunktaucclib/rest_handler/util.py
@@ -15,17 +15,20 @@
 #
 
 import os.path
+from typing import Optional
+
+import solnlib.utils as utils
 
 from .error import RestError
 
 try:
     from splunk import admin
-except:
+except Exception:
     print("Some functions will not be available outside of a splunk hosted process")
 
 try:
     from splunktalib.common import util
-except:
+except Exception:
     print('Python Lib for Splunk add-on "splunktalib" is required')
     raise BaseException()
 
@@ -95,3 +98,44 @@ def remove_http_proxy_env_vars():
             del os.environ[k]
         elif k.upper() in os.environ:
             del os.environ[k.upper()]
+
+
+def get_proxy_uri(proxy) -> Optional[str]:
+    """
+    :proxy: dict like, proxy information are in the following
+            format {
+                "proxy_url": zz,
+                "proxy_port": aa,
+                "proxy_username": bb,
+                "proxy_password": cc,
+                "proxy_type": http,sock4,sock5,
+                "proxy_rdns": 0 or 1,
+            }
+    :return: proxy uri or None
+    """
+    uri = None
+    if proxy and proxy.get("proxy_url") and proxy.get("proxy_type"):
+        uri = proxy["proxy_url"]
+        # socks5 causes the DNS resolution to happen on the client
+        # socks5h causes the DNS resolution to happen on the proxy server
+        if proxy.get("proxy_type") == "socks5" and utils.is_true(
+            proxy.get("proxy_rdns")
+        ):
+            proxy["proxy_type"] = "socks5h"
+        # setting default value of proxy_type to "http" if
+        # its value is not from ["http", "socks4", "socks5"]
+        if proxy.get("proxy_type") not in ["http", "socks4", "socks5"]:
+            proxy["proxy_type"] = "http"
+        if proxy.get("proxy_port"):
+            uri = "{}:{}".format(uri, proxy.get("proxy_port"))
+        if proxy.get("proxy_username") and proxy.get("proxy_password"):
+            uri = "{}://{}:{}@{}/".format(
+                proxy["proxy_type"],
+                proxy["proxy_username"],
+                proxy["proxy_password"],
+                uri,
+            )
+        else:
+            uri = "{}://{}".format(proxy["proxy_type"], uri)
+
+    return uri

--- a/splunktaucclib/rest_handler/util.py
+++ b/splunktaucclib/rest_handler/util.py
@@ -15,7 +15,7 @@
 #
 
 import os.path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import solnlib.utils as utils
 
@@ -100,7 +100,7 @@ def remove_http_proxy_env_vars():
             del os.environ[k.upper()]
 
 
-def get_proxy_uri(proxy) -> Optional[str]:
+def get_proxy_uri(proxy: Dict[str, Any]) -> Optional[str]:
     """
     :proxy: dict like, proxy information are in the following
             format {


### PR DESCRIPTION
Changes:

- feat: migration from httplib2 to requests library
- BREAKING CHANGE: the 'build_http_connection function of alert_actions_base.py has been deprecated. Users can use 'send_http_request' function of the same class or use 'requests.request' function.
- Changes related to 'splunkd_request' and 'code_to_msg' function of splunktalib.rest (of [this](https://github.com/splunk/addonfactory-ta-library-python/pull/48) PR) has been included in this PR.

**Changes needs to be done before merging this PR:**

- Need to update the version of splunktalib (comprises the changes of [this](https://github.com/splunk/addonfactory-ta-library-python/pull/48) PR) in the pyproject.toml file.