### PR TITLE
feat: migration from httplib2 to requests library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -70,17 +70,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "httplib2"
-version = "0.20.2"
-description = "A comprehensive HTTP client library."
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
-
-[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -151,9 +140,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pytest"
@@ -242,7 +239,7 @@ python-versions = "*"
 
 [[package]]
 name = "splunktalib"
-version = "2.2.6"
+version = "3.0.0b1"
 description = "Supporting library for Splunk Add-ons"
 category = "main"
 optional = false
@@ -250,7 +247,7 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 defusedxml = ">=0,<1"
-httplib2 = ">=0,<1"
+requests = ">=2.26.0,<3.0.0"
 sortedcontainers = ">=2,<3"
 
 [[package]]
@@ -305,7 +302,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6a3760090298e4c62d7485af9f96559ad5d83a016e1b4cc9d629f610dcdd3fff"
+content-hash = "e046fbe18cc7c4b43039236600e9f874b61d9907087433ab9b7173338e2f60db"
 
 [metadata.files]
 atomicwrites = [
@@ -381,10 +378,6 @@ defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-httplib2 = [
-    {file = "httplib2-0.20.2-py3-none-any.whl", hash = "sha256:6b937120e7d786482881b44b8eec230c1ee1c5c1d06bce8cc865f25abbbf713b"},
-    {file = "httplib2-0.20.2.tar.gz", hash = "sha256:e404681d2fbcec7506bcb52c503f2b021e95bee0ef7d01e5c221468a2406d8dc"},
-]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
@@ -413,6 +406,11 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pysocks = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
@@ -437,8 +435,8 @@ splunk-sdk = [
     {file = "splunk-sdk-1.6.18.tar.gz", hash = "sha256:edc0959786f5dcab225ba98633c310dbf7584977849f6c2152a0e5090b5e2561"},
 ]
 splunktalib = [
-    {file = "splunktalib-2.2.6-py3-none-any.whl", hash = "sha256:bba70ac7407cdedcb45437cb152ac0e43aae16b978031308e6bec548d3543119"},
-    {file = "splunktalib-2.2.6.tar.gz", hash = "sha256:8d58d697a842319b4c675557b0cc4a9c68e8d909389a98ed240e2bb4ff358d31"},
+    {file = "splunktalib-3.0.0b1-py3-none-any.whl", hash = "sha256:a22a5bf7e5451b94acc491a9d5c62c01778896e9705b481c825a7513b3634a4d"},
+    {file = "splunktalib-3.0.0b1.tar.gz", hash = "sha256:141341f522641d9e24362445daeb23aef502b1fbf4a3bb90ae196cfd0b6c64fb"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -239,7 +239,7 @@ python-versions = "*"
 
 [[package]]
 name = "splunktalib"
-version = "3.0.0b1"
+version = "3.0.0"
 description = "Supporting library for Splunk Add-ons"
 category = "main"
 optional = false
@@ -302,7 +302,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e046fbe18cc7c4b43039236600e9f874b61d9907087433ab9b7173338e2f60db"
+content-hash = "4a797bacd9604253483214207acaa9201f5f42c113236420c17304b93a9864fd"
 
 [metadata.files]
 atomicwrites = [
@@ -435,8 +435,8 @@ splunk-sdk = [
     {file = "splunk-sdk-1.6.18.tar.gz", hash = "sha256:edc0959786f5dcab225ba98633c310dbf7584977849f6c2152a0e5090b5e2561"},
 ]
 splunktalib = [
-    {file = "splunktalib-3.0.0b1-py3-none-any.whl", hash = "sha256:a22a5bf7e5451b94acc491a9d5c62c01778896e9705b481c825a7513b3634a4d"},
-    {file = "splunktalib-3.0.0b1.tar.gz", hash = "sha256:141341f522641d9e24362445daeb23aef502b1fbf4a3bb90ae196cfd0b6c64fb"},
+    {file = "splunktalib-3.0.0-py3-none-any.whl", hash = "sha256:371aa9ba95e4535458f2a8b981a50f039a1f973818f27ef542ecd827cae5f462"},
+    {file = "splunktalib-3.0.0.tar.gz", hash = "sha256:0a4e87b8b94f2cdd6be21f00e40d07e8167fcbd5540ac492fe3586b1ec98c25a"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "APACHE-2.0"
 python = "^3.7"
 solnlib = "^4.0.0"
 splunk-sdk = "^1.6.16"
-splunktalib = "^3.0.0b1"
+splunktalib = "^3.0.0"
 requests = "^2.26.0"
 PySocks = "^1.7.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ license = "APACHE-2.0"
 python = "^3.7"
 solnlib = "^4.0.0"
 splunk-sdk = "^1.6.16"
-splunktalib = "^2.0.0"
+splunktalib = "^3.0.0b1"
+requests = "^2.26.0"
+PySocks = "^1.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/splunktaucclib/rest_handler/base.py
+++ b/splunktaucclib/rest_handler/base.py
@@ -21,7 +21,6 @@ import copy
 import itertools
 import json
 import logging
-import sys
 from inspect import ismethod
 from os import path as op
 
@@ -68,15 +67,15 @@ def user_caps(mgmt_uri, session_key):
     """
     url = mgmt_uri + "/services/authentication/current-context"
 
-    resp, cont = splunkd_request(
+    resp = splunkd_request(
         url, session_key, method="GET", data={"output_mode": "json"}, retry=3
     )
     if resp is None:
         RH_Err.ctl(500, logging.ERROR, "Fail to get capabilities of sessioned user")
-    elif resp.status not in (200, "200"):
-        RH_Err.ctl(resp.status, logging.ERROR, cont)
+    elif resp.status_code != 200:
+        RH_Err.ctl(resp.status_code, logging.ERROR, resp.text)
 
-    cont = json.loads(cont)
+    cont = resp.json()
     caps = cont["entry"][0]["content"]["capabilities"]
     return set(caps)
 
@@ -288,7 +287,7 @@ class BaseRestHandler(admin.MConfigHandler):
     def handleCreate(self, confInfo):
         try:
             self.get(self.callerArgs.id)
-        except:
+        except Exception:
             pass
         else:
             RH_Err.ctl(

--- a/splunktaucclib/rest_handler/base.py
+++ b/splunktaucclib/rest_handler/base.py
@@ -285,7 +285,7 @@ class BaseRestHandler(admin.MConfigHandler):
         self.handleList(confInfo)
 
     def handleCreate(self, confInfo):
-        try:
+        try:  # nosemgrep: gitlab.bandit.B110
             self.get(self.callerArgs.id)
         except Exception:
             pass

--- a/splunktaucclib/rest_handler/poster.py
+++ b/splunktaucclib/rest_handler/poster.py
@@ -98,7 +98,7 @@ class PosterHandler(base.BaseRestHandler):
                 "Content-Type": "application/x-www-form-urlencoded",
             }
 
-            resp = requests.request(
+            resp = requests.request(  # nosemgrep: python.requests.best-practice.use-raise-for-status.use-raise-for-status  # noqa: E501
                 method=method,
                 url=url,
                 headers=headers,

--- a/splunktaucclib/rest_handler/teardown.py
+++ b/splunktaucclib/rest_handler/teardown.py
@@ -99,7 +99,7 @@ class TeardownHandler(base.BaseRestHandler):
 
     def clean(self, endpoint):
         url = self.make_uri(endpoint) + "?count=-1"
-        resp, cont = splunkd_request(
+        resp = splunkd_request(
             url,
             self.getSessionKey(),
             method="GET",
@@ -109,10 +109,10 @@ class TeardownHandler(base.BaseRestHandler):
 
         if resp is None:
             return {url: "Unknown reason"}
-        if resp.status != 200:
-            return {url: self.convertErrMsg(cont)}
+        if resp.status_code != 200:
+            return {url: self.convertErrMsg(resp.text)}
 
-        cont = json.loads(cont)
+        cont = resp.json()
         ents = [ent["name"] for ent in cont.get("entry", [])]
         errs = {}
         for ent in ents:
@@ -120,7 +120,7 @@ class TeardownHandler(base.BaseRestHandler):
             if not self.distinguish(endpoint, ent, **args):
                 continue
             url_ent = self.make_uri(endpoint, entry=ent)
-            resp, cont = splunkd_request(
+            resp = splunkd_request(
                 url_ent,
                 self.getSessionKey(),
                 method="DELETE",
@@ -130,7 +130,7 @@ class TeardownHandler(base.BaseRestHandler):
 
             if resp is None:
                 errs[url_ent] = "Unknown reason"
-            if resp.status != 200:
+            if resp.status_code != 200:
                 errs[url_ent] = self.convertErrMsg(cont)
         return errs
 


### PR DESCRIPTION
Changes:

- feat: migration from httplib2 to requests library
 - BREAKING CHANGE: the 'build_http_connection function of alert_actions_base.py has been deprecated. Users can use 'send_http_request' function of the same class or use 'requests.request' function.