### PR TITLE
fix: ingestion for XML streaming mode

### DIFF
--- a/splunktaucclib/data_collection/ta_data_collector.py
+++ b/splunktaucclib/data_collection/ta_data_collector.py
@@ -18,9 +18,8 @@
 
 import threading
 import time
+import xml.sax.saxutils as xss
 from collections import namedtuple
-
-import splunktalib.common.util as scu
 
 import splunktaucclib.common.log as stulog
 
@@ -32,7 +31,7 @@ evt_fmt = (
     "<sourcetype><![CDATA[{2}]]></sourcetype>"
     "<time>{3}</time>"
     "<index>{4}</index><data>"
-    "<![CDATA[{5}]]></data></event></stream>"
+    "{5}</data></event></stream>"
 )
 
 unbroken_evt_fmt = (
@@ -43,7 +42,7 @@ unbroken_evt_fmt = (
     "<sourcetype><![CDATA[{2}]]></sourcetype>"
     "<time>{3}</time>"
     "<index>{4}</index>"
-    "<data><![CDATA[{5}]]></data>"
+    "<data>{5}</data>"
     "{6}"
     "</event>"
     "</stream>"
@@ -123,7 +122,7 @@ class TADataCollector:
                     event.sourcetype or "",
                     event.time or "",
                     event.index or "",
-                    scu.escape_cdata(event.raw_data),
+                    xss.escape(event.raw_data),
                     "<done/>" if event.is_done else "",
                 )
             else:
@@ -133,7 +132,7 @@ class TADataCollector:
                     event.sourcetype or "",
                     event.time or "",
                     event.index or "",
-                    scu.escape_cdata(event.raw_data),
+                    xss.escape(event.raw_data),
                 )
             evts.append(evt)
         return evts

--- a/splunktaucclib/data_collection/ta_data_collector.py
+++ b/splunktaucclib/data_collection/ta_data_collector.py
@@ -18,7 +18,7 @@
 
 import threading
 import time
-import xml.sax.saxutils as xss
+import defusedxml.sax.saxutils as xss
 from collections import namedtuple
 
 import splunktaucclib.common.log as stulog

--- a/splunktaucclib/data_collection/ta_data_collector.py
+++ b/splunktaucclib/data_collection/ta_data_collector.py
@@ -18,8 +18,9 @@
 
 import threading
 import time
-import defusedxml.sax.saxutils as xss
 from collections import namedtuple
+
+import defusedxml.sax.saxutils as xss
 
 import splunktaucclib.common.log as stulog
 


### PR DESCRIPTION
There is a bug when you are trying to ingest `[{"Data": "Sample1"}, {"Data": "Sample2"}]`
it becomes `[{"Data": "Sample1"}, {"Data": "Sample2"}%5D` in Splunk because of the
`splunktalib`'s `escape_cdata` function used.

This PR removes usage of this function and uses `defusedxml.sax.saxutils.escape` function to escape
all the characters before sending to Splunk.

P.S. You can play with it using this repository:
https://github.com/artemrys/splunk-xml-streaming-minimal-example.