### PR TITLE
fix: data collection on SHC

### DIFF
--- a/splunktaucclib/data_collection/ta_mod_input.py
+++ b/splunktaucclib/data_collection/ta_mod_input.py
@@ -138,11 +138,6 @@ def run(collector_cls, settings, checkpoint_cls=None, config_cls=None, log_suffi
         return
     meta_config = tconfig.get_meta_config()
 
-    if tconfig.is_shc_but_not_captain():
-        # In SHC env, only captain is able to collect data
-        stulog.logger.debug("This search header is not captain, will exit.")
-        return
-
     loader = dl.create_data_loader(meta_config)
 
     jobs = [


### PR DESCRIPTION
This fix was tested to work on Noah and Classic architectures.

Similar situation (in 2016...): https://community.splunk.com/t5/All-Apps-and-Add-ons/Splunk-Add-on-for-Tenable-Why-is-the-add-on-not-able-to/m-p/230462