### PR TITLE
fix: look for the passwords in the particular realm, not all the passwords

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -313,7 +313,7 @@ doc = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "solnlib"
-version = "4.6.2"
+version = "4.7.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 category = "main"
 optional = false
@@ -425,7 +425,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "54cc166c43ee1c9ae3ed13f8da50e0f0ecb2eddb404f17ddf119db1cea9c5e44"
+content-hash = "477422a2e16a9a5326d773a075d6fa2af8b26f5e3a52d0c0900523d393908d70"
 
 [metadata.files]
 addonfactory-splunk-conf-parser-lib = [
@@ -504,10 +504,7 @@ coverage = [
     {file = "coverage-6.4.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1"},
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
-defusedxml = [
-    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
-    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
-]
+defusedxml = []
 dunamai = [
     {file = "dunamai-1.12.0-py3-none-any.whl", hash = "sha256:00b9c1ef58d4950204f76c20f84afe7a28d095f77feaa8512dbb172035415e61"},
     {file = "dunamai-1.12.0.tar.gz", hash = "sha256:fac4f09e2b8a105bd01f8c50450fea5aa489a6c439c949950a65f0dd388b0d20"},
@@ -515,10 +512,7 @@ dunamai = [
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
-idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
-]
+idna = []
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
     {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
@@ -620,11 +614,7 @@ pyrsistent = [
     {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
     {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
-pysocks = [
-    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
-    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
-    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
-]
+pysocks = []
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
     {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
@@ -633,22 +623,16 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
-requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
-]
+requests = []
 semantic-version = [
     {file = "semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"},
     {file = "semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c"},
 ]
 solnlib = [
-    {file = "solnlib-4.6.2-py3-none-any.whl", hash = "sha256:738bafec69425acaeef1b3b74376f6741c2eb830856f2086d079d7465cd13ddf"},
-    {file = "solnlib-4.6.2.tar.gz", hash = "sha256:86bf29c1f56e6c87d55ccd66317d106e317dfdc4f9ff2c9ea60f1cadb70daeec"},
+    {file = "solnlib-4.7.0-py3-none-any.whl", hash = "sha256:80d62f13b69a3756d6039b7c266e6f7410ccc03411a555b91d996982730adc68"},
+    {file = "solnlib-4.7.0.tar.gz", hash = "sha256:85c341927c364b9ed0bb42fffdcc0d1477545e9dbd12db59f217cc8fa964a64e"},
 ]
-sortedcontainers = [
-    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
-    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
-]
+sortedcontainers = []
 splunk-add-on-ucc-framework = [
     {file = "splunk_add_on_ucc_framework-5.13.0-py3-none-any.whl", hash = "sha256:ab212274654527378f198ffdf50165b3a083b291dece593e5ecda4fb38c63903"},
     {file = "splunk_add_on_ucc_framework-5.13.0.tar.gz", hash = "sha256:edb40a25b2652c5470ca9eb309c725b5ff4ec516cc1b76c7883f513342268016"},
@@ -659,10 +643,7 @@ splunk-packaging-toolkit = [
 splunk-sdk = [
     {file = "splunk-sdk-1.7.1.tar.gz", hash = "sha256:4d0de12a87395f28f2a0c90b179882072a39a1f09a3ec9e79ce0de7a16220fe1"},
 ]
-splunktalib = [
-    {file = "splunktalib-3.0.1-py3-none-any.whl", hash = "sha256:26d4c68e898a1a96cf5b65d9fe295bf315ec5327484f2ee1c3e1cf4e40ffc802"},
-    {file = "splunktalib-3.0.1.tar.gz", hash = "sha256:a7e83e5f9f92ae2a9dedd8ee2e51b4df1a79dd42c6b9dddded20017da40d9d73"},
-]
+splunktalib = []
 tomli = [
     {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
     {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ license = "APACHE-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-solnlib = "^4.0.0"
 splunktalib = "^3.0.0"
 requests = "^2.26.0"
 PySocks = "^1.7.1"
 splunk-sdk = ">=1.6.18"
+solnlib = "^4.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"

--- a/splunktaucclib/rest_handler/credentials.py
+++ b/splunktaucclib/rest_handler/credentials.py
@@ -289,9 +289,7 @@ class RestCredentials:
             host=self._splunkd_info.hostname,
             port=self._splunkd_info.port,
         )
-
-        all_passwords = credential_manager._get_all_passwords()
-        # filter by realm
+        all_passwords = credential_manager.get_clear_passwords_in_realm()
         realm_passwords = [x for x in all_passwords if x["realm"] == self._realm]
         return self._merge_passwords(data, realm_passwords)
 


### PR DESCRIPTION
Similar to https://github.com/splunk/addonfactory-solutions-library-python/pull/189.

This change should fix the situation when you try to get a specific password for you add-on
and some other password in other add-on is corrupted, then the configuration page is
not loading for all the add-ons.

**This fix requires solnlib to be at least 4.7.0 version.**