### PR TITLE
feat: update apps naming to be Splunk 9 only

### DIFF
--- a/splunktaucclib/rest_handler/util.py
+++ b/splunktaucclib/rest_handler/util.py
@@ -82,7 +82,7 @@ def get_base_app_name():
     absolute_path = os.path.normpath(main_name)
     parts = absolute_path.split(os.path.sep)
     parts.reverse()
-    for key in ("apps", "slave-apps", "master-apps"):
+    for key in ("apps", "peer-apps", "manager-apps"):
         try:
             idx = parts.index(key)
             if parts[idx + 1] == "etc":


### PR DESCRIPTION
Splunk 9 introduces "peer-apps" instead of "slave-apps" and "manager-apps" instead of "master-apps".

This change should be merged after Splunk 8 is EOL, which is May 12, 2023.

https://docs.splunk.com/Documentation/Splunk/latest/Indexer/Updatepeerconfigurations