### PR TITLE
ci: temporary disable semgrep for release

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -156,7 +156,6 @@ jobs:
   publish:
     needs:
       - pre-commit
-      - semgrep
       - build
       - unit-tests
       - integration-tests


### PR DESCRIPTION
The semgrep is failing because of some `hashlib` library usage which is not related to the fix that is being proposed. This needs to be investigated later.