### PR TITLE
chore: update from poetry dev-dependencies to group.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ PySocks = "^1.7.1"
 splunk-sdk = ">=1.6"
 solnlib = "^4.11.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=7"
 splunk-add-on-ucc-framework = ">=5"
 splunk-packaging-toolkit = ">=1"


### PR DESCRIPTION
This is a technical change to make sure we use latest poetry syntax to specify dev dependencies.