### PR TITLE
chore: update licence headers to 2024

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/__init__.py
+++ b/splunktaucclib/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/alert_actions_base.py
+++ b/splunktaucclib/alert_actions_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/cim_actions.py
+++ b/splunktaucclib/cim_actions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/common/__init__.py
+++ b/splunktaucclib/common/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/common/log.py
+++ b/splunktaucclib/common/log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/config.py
+++ b/splunktaucclib/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/__init__.py
+++ b/splunktaucclib/data_collection/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_checkpoint_manager.py
+++ b/splunktaucclib/data_collection/ta_checkpoint_manager.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_config.py
+++ b/splunktaucclib/data_collection/ta_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_consts.py
+++ b/splunktaucclib/data_collection/ta_consts.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_data_client.py
+++ b/splunktaucclib/data_collection/ta_data_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_data_collector.py
+++ b/splunktaucclib/data_collection/ta_data_collector.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_data_loader.py
+++ b/splunktaucclib/data_collection/ta_data_loader.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_helper.py
+++ b/splunktaucclib/data_collection/ta_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/data_collection/ta_mod_input.py
+++ b/splunktaucclib/data_collection/ta_mod_input.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/global_config/__init__.py
+++ b/splunktaucclib/global_config/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/global_config/configuration.py
+++ b/splunktaucclib/global_config/configuration.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/global_config/schema.py
+++ b/splunktaucclib/global_config/schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/modinput_wrapper/__init__.py
+++ b/splunktaucclib/modinput_wrapper/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/modinput_wrapper/base_modinput.py
+++ b/splunktaucclib/modinput_wrapper/base_modinput.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/__init__.py
+++ b/splunktaucclib/rest_handler/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/admin_external.py
+++ b/splunktaucclib/rest_handler/admin_external.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/base.py
+++ b/splunktaucclib/rest_handler/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/base_hook_mixin.py
+++ b/splunktaucclib/rest_handler/base_hook_mixin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/cred_mgmt.py
+++ b/splunktaucclib/rest_handler/cred_mgmt.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/credentials.py
+++ b/splunktaucclib/rest_handler/credentials.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/datainput.py
+++ b/splunktaucclib/rest_handler/datainput.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/eai.py
+++ b/splunktaucclib/rest_handler/eai.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/endpoint/converter.py
+++ b/splunktaucclib/rest_handler/endpoint/converter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/endpoint/field.py
+++ b/splunktaucclib/rest_handler/endpoint/field.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/endpoint/validator.py
+++ b/splunktaucclib/rest_handler/endpoint/validator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/entity.py
+++ b/splunktaucclib/rest_handler/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/error.py
+++ b/splunktaucclib/rest_handler/error.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/error_ctl.py
+++ b/splunktaucclib/rest_handler/error_ctl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/multimodel.py
+++ b/splunktaucclib/rest_handler/multimodel.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/normaliser.py
+++ b/splunktaucclib/rest_handler/normaliser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/poster.py
+++ b/splunktaucclib/rest_handler/poster.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/schema.py
+++ b/splunktaucclib/rest_handler/schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/teardown.py
+++ b/splunktaucclib/rest_handler/teardown.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/util.py
+++ b/splunktaucclib/rest_handler/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/rest_handler/validator.py
+++ b/splunktaucclib/rest_handler/validator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/splunk_aoblib/__init__.py
+++ b/splunktaucclib/splunk_aoblib/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/splunk_aoblib/rest_helper.py
+++ b/splunktaucclib/splunk_aoblib/rest_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/splunk_aoblib/rest_migration.py
+++ b/splunktaucclib/splunk_aoblib/rest_migration.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/splunk_aoblib/setup_util.py
+++ b/splunktaucclib/splunk_aoblib/setup_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunktaucclib/splunk_aoblib/utility.py
+++ b/splunktaucclib/splunk_aoblib/utility.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
update copyright license headers for 2024