### PR TITLE
fix: add support for solnlib v5.x.x

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -103,11 +103,11 @@ jobs:
           - "3.11"
     steps:
       - uses: actions/checkout@v4
-      - run: pipx install poetry==1.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
+      - run: pipx install poetry==1.5.1
       - name: run tests
         run: |
           poetry install

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -131,7 +131,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.7
-          cache: "poetry"
       - run: poetry install
       - name: build demo add-on
         run: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -106,7 +106,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "poetry"
       - run: pipx install poetry==1.5.1
       - name: run tests
         run: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -75,11 +75,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - run: pipx install poetry==1.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.7"
-          cache: "poetry"
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - name: Install Poetry
         run: |
           poetry build
@@ -106,7 +105,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pipx install poetry==1.5.1
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - name: run tests
         run: |
           poetry install
@@ -127,10 +126,10 @@ jobs:
       SPLUNK_ADMIN_PWD: Chang3d'!'
     steps:
       - uses: actions/checkout@v4
-      - run: pipx install poetry==1.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: 3.7
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - run: poetry install
       - name: build demo add-on
         run: |
@@ -179,11 +178,10 @@ jobs:
           # Very important: semantic-release won't trigger a tagged
           # build if this is not set false
           persist-credentials: false
-      - run: pipx install poetry==1.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.7"
-          cache: "poetry"
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - name: Install and build
         run: |
           poetry install

--- a/poetry.lock
+++ b/poetry.lock
@@ -614,13 +614,13 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "solnlib"
-version = "5.0.0"
+version = "4.14.1"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "solnlib-5.0.0-py3-none-any.whl", hash = "sha256:84b45ce627c2a6d7fafe08d93bb887699768f96ab56d4f115598e66c3d34beb3"},
-    {file = "solnlib-5.0.0.tar.gz", hash = "sha256:351d5121c5b6804a71d0ec70b7763cca7c50410173df8620db543203d1c8f7b6"},
+    {file = "solnlib-4.14.1-py3-none-any.whl", hash = "sha256:ef86a38f8860b659064851339f5f89077aad54cf468396d4905a892a27e25bed"},
+    {file = "solnlib-4.14.1.tar.gz", hash = "sha256:cfe3a5c7e9214730746e6e21063dfc50dd6e7d85935a77721e78d76284b976ff"},
 ]
 
 [package.dependencies]
@@ -764,4 +764,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "dbaf816ec3621d2b3e6653b8b26ac4e3f0157db15dd1b8a5e17cc55ce1a438a2"
+content-hash = "18f4192313561cc492bfb27203455272d5cd6d517d64ae393da6de7ed319fa76"

--- a/poetry.lock
+++ b/poetry.lock
@@ -542,7 +542,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -615,13 +614,13 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "solnlib"
-version = "4.14.1"
+version = "5.0.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "solnlib-4.14.1-py3-none-any.whl", hash = "sha256:ef86a38f8860b659064851339f5f89077aad54cf468396d4905a892a27e25bed"},
-    {file = "solnlib-4.14.1.tar.gz", hash = "sha256:cfe3a5c7e9214730746e6e21063dfc50dd6e7d85935a77721e78d76284b976ff"},
+    {file = "solnlib-5.0.0-py3-none-any.whl", hash = "sha256:84b45ce627c2a6d7fafe08d93bb887699768f96ab56d4f115598e66c3d34beb3"},
+    {file = "solnlib-5.0.0.tar.gz", hash = "sha256:351d5121c5b6804a71d0ec70b7763cca7c50410173df8620db543203d1c8f7b6"},
 ]
 
 [package.dependencies]
@@ -765,4 +764,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "18f4192313561cc492bfb27203455272d5cd6d517d64ae393da6de7ed319fa76"
+content-hash = "dbaf816ec3621d2b3e6653b8b26ac4e3f0157db15dd1b8a5e17cc55ce1a438a2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -614,13 +614,13 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "solnlib"
-version = "4.14.1"
+version = "5.0.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "solnlib-4.14.1-py3-none-any.whl", hash = "sha256:ef86a38f8860b659064851339f5f89077aad54cf468396d4905a892a27e25bed"},
-    {file = "solnlib-4.14.1.tar.gz", hash = "sha256:cfe3a5c7e9214730746e6e21063dfc50dd6e7d85935a77721e78d76284b976ff"},
+    {file = "solnlib-5.0.0-py3-none-any.whl", hash = "sha256:84b45ce627c2a6d7fafe08d93bb887699768f96ab56d4f115598e66c3d34beb3"},
+    {file = "solnlib-5.0.0.tar.gz", hash = "sha256:351d5121c5b6804a71d0ec70b7763cca7c50410173df8620db543203d1c8f7b6"},
 ]
 
 [package.dependencies]
@@ -764,4 +764,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "18f4192313561cc492bfb27203455272d5cd6d517d64ae393da6de7ed319fa76"
+content-hash = "dbaf816ec3621d2b3e6653b8b26ac4e3f0157db15dd1b8a5e17cc55ce1a438a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requests = "^2.31.0"
 urllib3 = "<2"
 PySocks = "^1.7.1"
 splunk-sdk = ">=1.6"
-solnlib = "^5.0.0"
+solnlib = "^4.11.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requests = "^2.31.0"
 urllib3 = "<2"
 PySocks = "^1.7.1"
 splunk-sdk = ">=1.6"
-solnlib = "^4.11.2"
+solnlib = "^5.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"

--- a/splunktaucclib/common/log.py
+++ b/splunktaucclib/common/log.py
@@ -44,7 +44,7 @@ def _get_log_level(log_level, default_level=logging.INFO):
 
 def set_log_level(log_level):
     """
-    Set log level.
+    Set log level. Test message.
     """
     stclog.Logs().set_level(_get_log_level(log_level))
 

--- a/splunktaucclib/common/log.py
+++ b/splunktaucclib/common/log.py
@@ -44,7 +44,7 @@ def _get_log_level(log_level, default_level=logging.INFO):
 
 def set_log_level(log_level):
     """
-    Set log level. Test message.
+    Set log level.
     """
     stclog.Logs().set_level(_get_log_level(log_level))
 


### PR DESCRIPTION
support for solnlib library which was recently released with version v5.0.0
fix ci:
*removed cache poetry
*removed pipx installer
*change step order - `actions/setup-python@v5` before installing poetry