### PR TITLE
fix: remove buffer disabling

### DIFF
--- a/splunktaucclib/data_collection/ta_data_client.py
+++ b/splunktaucclib/data_collection/ta_data_client.py
@@ -18,6 +18,22 @@
 
 import splunktaucclib.data_collection.ta_data_collector as tdc
 from splunktaucclib.data_collection import ta_checkpoint_manager as cp
+from solnlib.modular_input import event_writer as ew
+
+
+def get_event_writer_factory():
+    instance = None
+
+    def get_instance():
+        nonlocal instance
+        if instance is None:
+            instance = ew.ClassicEventWriter()
+        return instance
+
+    return get_instance
+
+
+get_event_writer = get_event_writer_factory()
 
 
 def build_event(
@@ -32,8 +48,16 @@ def build_event(
 ):
     if is_unbroken is False and is_done is True:
         raise Exception("is_unbroken=False is_done=True is invalid")
-    return tdc.event_tuple._make(
-        [host, source, sourcetype, time, index, raw_data, is_unbroken, is_done]
+    writer = get_event_writer()
+    return writer.create_event(
+        raw_data,
+        time,
+        index,
+        host,
+        source,
+        sourcetype,
+        unbroken=is_unbroken,
+        done=is_done,
     )
 
 

--- a/splunktaucclib/data_collection/ta_data_loader.py
+++ b/splunktaucclib/data_collection/ta_data_loader.py
@@ -39,7 +39,7 @@ class TADataLoader:
         @configs: a list like object containing a list of dict
         like object. Each element shall implement dict.get/[] like interfaces
         to get the value for a key.
-        @job_scheduler: schedulering the jobs. shall implement get_ready_jobs
+        @job_scheduler: scheduling the jobs. shall implement get_ready_jobs
         @event_writer: write_events
         """
 
@@ -58,7 +58,6 @@ class TADataLoader:
             return
         self._started = True
 
-        self._event_writer.start()
         self._executor.start()
         self._timer_queue.start()
         self._scheduler.start()
@@ -81,7 +80,6 @@ class TADataLoader:
         self._scheduler.tear_down()
         self._timer_queue.tear_down()
         self._executor.tear_down()
-        self._event_writer.tear_down()
         log.logger.info("DataLoader stopped.")
 
     def _wait_for_tear_down(self):
@@ -166,13 +164,13 @@ class GlobalDataLoader:
 
 def create_data_loader(meta_configs):
     """
-    create a data loader with default event_writer, job_scheudler
+    create a data loader with default event_writer, job_scheduler
     """
 
-    import splunktalib.event_writer as ew
+    import solnlib.modular_input.event_writer as ew
     import splunktalib.schedule.scheduler as sched
 
-    writer = ew.EventWriter()
+    writer = ew.ClassicEventWriter()
     scheduler = sched.Scheduler()
     loader = GlobalDataLoader.get_data_loader(meta_configs, scheduler, writer)
     return loader

--- a/splunktaucclib/data_collection/ta_mod_input.py
+++ b/splunktaucclib/data_collection/ta_mod_input.py
@@ -123,8 +123,6 @@ def run(collector_cls, settings, checkpoint_cls=None, config_cls=None, log_suffi
     """
     Main loop. Run this TA forever
     """
-    # This is for stdout flush
-    utils.disable_stdout_buffer()
 
     # http://bugs.python.org/issue7980
     time.strptime("2016-01-01", "%Y-%m-%d")


### PR DESCRIPTION
This PR is a potential fix for Segmentation Faults in Python 3.9 (more info here https://splunk.atlassian.net/browse/ADDON-71136). 

We found out that disabling stdout buffer implemented in `splunktalib` doesn't work for Python 3.8 & 3.9 (for 3.7 and >3.10 it works). The problem is with [this line](https://github.com/splunk/addonfactory-ta-library-python/blob/main/splunktalib/common/util.py#L142) (it every Python code, not only our TAs):
```
sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", 0)
```
This problem affects everyone who uses `splunktaucclib`'s framework for modinputs.

As a solution, we removed disabling buffer and decided to flush immediately (as `ClassicEventWriter` from `solnlib` does).