### PR TITLE
ci: use reusable workflow for semgrep

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -58,13 +58,9 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   semgrep:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - id: semgrep
-        uses: semgrep/semgrep-action@v1
-        with:
-          publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
+    uses: splunk/sast-scanning/.github/workflows/sast-scan.yml@main
+    secrets:
+      SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated the build-test-release workflow to use [sast-scan](https://github.com/splunk/sast-scanning) owned by product security team instead of using custom implementation.
Ref: https://splunk.atlassian.net/browse/ADDON-72309