### PR TITLE
feat: add default and custom validations for name field

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -113,6 +113,7 @@ jobs:
       - meta
       - test-unit
     strategy:
+      fail-fast: false
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
     env:

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -33,6 +33,7 @@ class RestModel:
         REST Model.
         :param name:
         :param fields:
+        :param special_fields:
         """
         self.name = name
         self.fields = fields

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import List
+from typing import List, Optional
 
 from .field import RestField
 from ..error import RestError
@@ -30,7 +30,9 @@ __all__ = [
 
 
 class RestModel:
-    def __init__(self, fields, name=None, special_fields: List[RestField] = None):
+    def __init__(
+        self, fields, name=None, special_fields: Optional[List[RestField]] = None
+    ):
         """
         REST Model.
         :param name:

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
 
 
 class RestModel:
-    def __init__(self, fields, name=None):
+    def __init__(self, fields, name=None, special_fields=None):
         """
         REST Model.
         :param name:
@@ -36,6 +36,7 @@ class RestModel:
         """
         self.name = name
         self.fields = fields
+        self.special_fields = special_fields if special_fields else []
 
 
 class RestEndpoint:
@@ -83,6 +84,13 @@ class RestEndpoint:
 
     def validate(self, name, data, existing=None):
         self._loop_fields("validate", name, data, existing=existing)
+
+    def _loop_field_special(self, meth, name, data, *args, **kwargs):
+        model = self.model(name)
+        return [getattr(f, meth)(data, *args, **kwargs) for f in model.special_fields]
+
+    def validate_special(self, name, data):
+        self._loop_field_special("validate", name, data, validate_name=name)
 
     def encode(self, name, data):
         self._loop_fields("encode", name, data)

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
+from typing import List
 
+from .field import RestField
 from ..error import RestError
 from ..util import get_base_app_name
 
@@ -28,7 +30,7 @@ __all__ = [
 
 
 class RestModel:
-    def __init__(self, fields, name=None, special_fields=None):
+    def __init__(self, fields, name=None, special_fields: List[RestField] = None):
         """
         REST Model.
         :param name:

--- a/splunktaucclib/rest_handler/endpoint/field.py
+++ b/splunktaucclib/rest_handler/endpoint/field.py
@@ -41,11 +41,11 @@ class RestField:
         self.validator = validator
         self.converter = converter
 
-    def validate(self, data, existing=None):
+    def validate(self, data, existing=None, validate_name=None):
         # update case: check required field in data
         if existing and self.name in data and not data.get(self.name) and self.required:
             raise RestError(400, "Required field is missing: %s" % self.name)
-        value = data.get(self.name)
+        value = data.get(self.name) if not validate_name else validate_name
         if not value and existing is None:
             if self.required:
                 raise RestError(400, "Required field is missing: %s" % self.name)

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -102,29 +102,24 @@ def _pre_request(existing):
             else:
                 return None
 
-        def basic_name_validation(name):
+        def basic_name_validation(name: str):
             tmp_name = str(name)
             prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
-            val_err_msg = (
-                (
-                    '"default", ".", "..", string started with "_" and string including any one of '
-                    '["*", "\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot '
-                    "be used for field Name"
-                ),
-            )
+            prohibited_names = ["default", ".", ".."]
+            max_chars = 1024
+            val_err_msg = (f'{prohibited_names}, string started with "_" and string including any one '
+                           f'of {prohibited_chars} are reserved value which cannot be used for field Name"')
+
             if (
-                tmp_name.startswith("_")
-                or tmp_name == "."
-                or tmp_name == ".."
-                or tmp_name == "default"
+                tmp_name.startswith("_") or any(tmp_name == el for el in prohibited_names)
             ):
                 raise RestError(400, val_err_msg)
 
             if any(pc in prohibited_chars for pc in tmp_name):
                 raise RestError(400, val_err_msg)
 
-            if len(tmp_name) >= 1024:
-                raise RestError(400, "Field Name must be less than 1024 characters")
+            if len(tmp_name) >= max_chars:
+                raise RestError(400, f"Field Name must be less than {max_chars} characters")
 
         @wraps(meth)
         def wrapper(self, name, data):

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -134,10 +134,7 @@ def _pre_request(existing):
                 check_existing(self, name),
             )
             basic_name_validation(name)
-            self._endpoint.validate_special(
-                name,
-                data
-            )
+            self._endpoint.validate_special(name, data)
             self._endpoint.encode(name, data)
 
             return meth(self, name, data)

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -37,7 +37,7 @@ __all__ = ["RestHandler"]
 BASIC_NAME_VALIDATORS = {
     "PROHIBITED_NAME_CHARACTERS": ["*", "\\", "[", "]", "(", ")", "?", ":"],
     "PROHIBITED_NAMES": ["default", ".", ".."],
-    "MAX_LENGTH": 1024
+    "MAX_LENGTH": 1024,
 }
 
 

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -102,6 +102,21 @@ def _pre_request(existing):
             else:
                 return None
 
+        def basic_name_validation(name):
+            tmp_name = str(name)
+            prohibited_chars = ['*', '\\', '[', ']', '(', ')', '?', ':']
+            val_err_msg = ('"default", ".", "..", string started with "_" and string including any one of '
+                           '["*", "\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot '
+                           'be used for field Name'),
+            if tmp_name.startswith("_") or tmp_name == "." or tmp_name == ".." or tmp_name == "default":
+                raise RestError(400, val_err_msg)
+
+            if any(pc in prohibited_chars for pc in tmp_name):
+                raise RestError(400, val_err_msg)
+
+            if len(tmp_name) >= 1024:
+                raise RestError(400, "Field Name must be less than 1024 characters")
+
         @wraps(meth)
         def wrapper(self, name, data):
             self._endpoint.validate(
@@ -109,6 +124,7 @@ def _pre_request(existing):
                 data,
                 check_existing(self, name),
             )
+            basic_name_validation(name)
             self._endpoint.encode(name, data)
 
             return meth(self, name, data)

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -104,11 +104,20 @@ def _pre_request(existing):
 
         def basic_name_validation(name):
             tmp_name = str(name)
-            prohibited_chars = ['*', '\\', '[', ']', '(', ')', '?', ':']
-            val_err_msg = ('"default", ".", "..", string started with "_" and string including any one of '
-                           '["*", "\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot '
-                           'be used for field Name'),
-            if tmp_name.startswith("_") or tmp_name == "." or tmp_name == ".." or tmp_name == "default":
+            prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
+            val_err_msg = (
+                (
+                    '"default", ".", "..", string started with "_" and string including any one of '
+                    '["*", "\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot '
+                    "be used for field Name"
+                ),
+            )
+            if (
+                tmp_name.startswith("_")
+                or tmp_name == "."
+                or tmp_name == ".."
+                or tmp_name == "default"
+            ):
                 raise RestError(400, val_err_msg)
 
             if any(pc in prohibited_chars for pc in tmp_name):

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -34,6 +34,12 @@ from .error import RestError
 
 __all__ = ["RestHandler"]
 
+BASIC_NAME_VALIDATORS = {
+    "PROHIBITED_NAME_CHARACTERS": ["*", "\\", "[", "]", "(", ")", "?", ":"],
+    "PROHIBITED_NAMES": ["default", ".", ".."],
+    "MAX_LENGTH": 1024
+}
+
 
 def _check_name_for_create(name):
     if name == "default":
@@ -104,9 +110,9 @@ def _pre_request(existing):
 
         def basic_name_validation(name: str):
             tmp_name = str(name)
-            prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
-            prohibited_names = ["default", ".", ".."]
-            max_chars = 1024
+            prohibited_chars = BASIC_NAME_VALIDATORS["PROHIBITED_NAME_CHARACTERS"]
+            prohibited_names = BASIC_NAME_VALIDATORS["PROHIBITED_NAMES"]
+            max_chars = BASIC_NAME_VALIDATORS["MAX_LENGTH"]
             val_err_msg = (
                 f'{prohibited_names}, string started with "_" and string including any one '
                 f'of {prohibited_chars} are reserved value which cannot be used for field Name"'

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -134,6 +134,10 @@ def _pre_request(existing):
                 check_existing(self, name),
             )
             basic_name_validation(name)
+            self._endpoint.validate_special(
+                name,
+                data
+            )
             self._endpoint.encode(name, data)
 
             return meth(self, name, data)

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -107,11 +107,13 @@ def _pre_request(existing):
             prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
             prohibited_names = ["default", ".", ".."]
             max_chars = 1024
-            val_err_msg = (f'{prohibited_names}, string started with "_" and string including any one '
-                           f'of {prohibited_chars} are reserved value which cannot be used for field Name"')
+            val_err_msg = (
+                f'{prohibited_names}, string started with "_" and string including any one '
+                f'of {prohibited_chars} are reserved value which cannot be used for field Name"'
+            )
 
-            if (
-                tmp_name.startswith("_") or any(tmp_name == el for el in prohibited_names)
+            if tmp_name.startswith("_") or any(
+                tmp_name == el for el in prohibited_names
             ):
                 raise RestError(400, val_err_msg)
 
@@ -119,7 +121,9 @@ def _pre_request(existing):
                 raise RestError(400, val_err_msg)
 
             if len(tmp_name) >= max_chars:
-                raise RestError(400, f"Field Name must be less than {max_chars} characters")
+                raise RestError(
+                    400, f"Field Name must be less than {max_chars} characters"
+                )
 
         @wraps(meth)
         def wrapper(self, name, data):
@@ -215,7 +219,7 @@ class RestHandler:
         response = self._client.get(
             self.path_segment(self._endpoint.internal_endpoint),
             output_mode="json",
-            **query
+            **query,
         )
         return self._format_all_response(response, decrypt)
 
@@ -403,7 +407,7 @@ class RestHandler:
                     self._endpoint.internal_endpoint,
                     name=name,
                 ),
-                **masked
+                **masked,
             )
 
     def _encrypt_raw_credentials(self, data):

--- a/tests/integration/demo/globalConfig.json
+++ b/tests/integration/demo/globalConfig.json
@@ -110,7 +110,6 @@
         "restRoot": "demo",
         "version": "0.0.1",
         "displayName": "Demo",
-        "schemaVersion": "0.0.8",
-        "_uccVersion": "5.45.0"
+        "schemaVersion": "0.0.8"
     }
 }

--- a/tests/integration/demo/globalConfig.json
+++ b/tests/integration/demo/globalConfig.json
@@ -3,41 +3,14 @@
         "configuration": {
             "tabs": [
                 {
-                    "name": "logging",
-                    "entity": [
-                        {
-                            "type": "singleSelect",
-                            "label": "Log level",
-                            "options": {
-                                "disableSearch": true,
-                                "autoCompleteFields": [
-                                    {
-                                        "value": "DEBUG",
-                                        "label": "DEBUG"
-                                    },
-                                    {
-                                        "value": "INFO",
-                                        "label": "INFO"
-                                    },
-                                    {
-                                        "value": "WARN",
-                                        "label": "WARN"
-                                    },
-                                    {
-                                        "value": "ERROR",
-                                        "label": "ERROR"
-                                    },
-                                    {
-                                        "value": "CRITICAL",
-                                        "label": "CRITICAL"
-                                    }
-                                ]
-                            },
-                            "defaultValue": "INFO",
-                            "field": "loglevel"
-                        }
-                    ],
-                    "title": "Logging"
+                    "type": "loggingTab",
+                    "levels": [
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "CRITICAL"
+                    ]
                 }
             ],
             "title": "Configuration",
@@ -55,7 +28,7 @@
                                 {
                                     "type": "regex",
                                     "errorMsg": "Input Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
-                                    "pattern": "^[a-zA-Z]\\w*$"
+                                    "pattern": "^[a-dA-D]\\w*$"
                                 },
                                 {
                                     "type": "string",
@@ -69,19 +42,12 @@
                             "required": true
                         },
                         {
-                            "type": "text",
-                            "label": "Interval",
-                            "validators": [
-                                {
-                                    "type": "regex",
-                                    "errorMsg": "Interval must be an integer.",
-                                    "pattern": "^\\-[1-9]\\d*$|^\\d*$"
-                                }
-                            ],
-                            "defaultValue": "300",
+                            "type": "interval",
                             "field": "interval",
+                            "label": "Interval",
                             "help": "Time interval of the data input, in seconds.",
-                            "required": true
+                            "required": true,
+                            "defaultValue": "300"
                         }
                     ],
                     "title": "Demo"
@@ -144,6 +110,7 @@
         "restRoot": "demo",
         "version": "0.0.1",
         "displayName": "Demo",
-        "schemaVersion": "0.0.3"
+        "schemaVersion": "0.0.8",
+        "_uccVersion": "5.45.0"
     }
 }

--- a/tests/integration/demo/package/bin/demo_rh_demo.py
+++ b/tests/integration/demo/package/bin/demo_rh_demo.py
@@ -1,0 +1,68 @@
+
+import import_declare_test
+
+from splunktaucclib.rest_handler.endpoint import (
+    field,
+    validator,
+    RestModel,
+    DataInputModel,
+)
+from splunktaucclib.rest_handler import admin_external, util
+from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
+import logging
+
+util.remove_http_proxy_env_vars()
+
+
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.Pattern(
+                regex=r"""^[a-dA-D]\w*$""", 
+            ), 
+            validator.String(
+                max_len=100, 
+                min_len=1, 
+            )
+        )
+    )
+]
+
+fields = [
+    field.RestField(
+        'interval',
+        required=True,
+        encrypted=False,
+        default='300',
+        validator=validator.Pattern(
+            regex=r"""^(?:-1|\d+(?:\.\d+)?)$""", 
+        )
+    ), 
+
+    field.RestField(
+        'disabled',
+        required=False,
+        validator=None
+    )
+
+]
+model = RestModel(fields, name=None, special_fields=special_fields)
+
+
+
+endpoint = DataInputModel(
+    'demo',
+    model,
+)
+
+
+if __name__ == '__main__':
+    logging.getLogger().addHandler(logging.NullHandler())
+    admin_external.handle(
+        endpoint,
+        handler=AdminExternalHandler,
+    )

--- a/tests/integration/demo/package/bin/demo_rh_demo.py
+++ b/tests/integration/demo/package/bin/demo_rh_demo.py
@@ -1,4 +1,3 @@
-
 import import_declare_test
 
 from splunktaucclib.rest_handler.endpoint import (
@@ -16,51 +15,44 @@ util.remove_http_proxy_env_vars()
 
 special_fields = [
     field.RestField(
-        'name',
+        "name",
         required=True,
         encrypted=False,
         default=None,
         validator=validator.AllOf(
             validator.Pattern(
-                regex=r"""^[a-dA-D]\w*$""", 
-            ), 
+                regex=r"""^[a-dA-D]\w*$""",
+            ),
             validator.String(
-                max_len=100, 
-                min_len=1, 
-            )
-        )
+                max_len=100,
+                min_len=1,
+            ),
+        ),
     )
 ]
 
 fields = [
     field.RestField(
-        'interval',
+        "interval",
         required=True,
         encrypted=False,
-        default='300',
+        default="300",
         validator=validator.Pattern(
-            regex=r"""^(?:-1|\d+(?:\.\d+)?)$""", 
-        )
-    ), 
-
-    field.RestField(
-        'disabled',
-        required=False,
-        validator=None
-    )
-
+            regex=r"""^(?:-1|\d+(?:\.\d+)?)$""",
+        ),
+    ),
+    field.RestField("disabled", required=False, validator=None),
 ]
 model = RestModel(fields, name=None, special_fields=special_fields)
 
 
-
 endpoint = DataInputModel(
-    'demo',
+    "demo",
     model,
 )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.getLogger().addHandler(logging.NullHandler())
     admin_external.handle(
         endpoint,

--- a/tests/integration/demo/package/bin/demo_rh_settings.py
+++ b/tests/integration/demo/package/bin/demo_rh_settings.py
@@ -1,4 +1,3 @@
-
 import import_declare_test
 
 from splunktaucclib.rest_handler.endpoint import (
@@ -14,31 +13,23 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
-special_fields = [
-
-]
+special_fields = []
 
 fields_logging = [
     field.RestField(
-        'loglevel',
-        required=True,
-        encrypted=False,
-        default='INFO',
-        validator=None
+        "loglevel", required=True, encrypted=False, default="INFO", validator=None
     )
 ]
-model_logging = RestModel(fields_logging, name='logging', special_fields=special_fields)
+model_logging = RestModel(fields_logging, name="logging", special_fields=special_fields)
 
 
 endpoint = MultipleModel(
-    'demo_settings',
-    models=[
-        model_logging
-    ],
+    "demo_settings",
+    models=[model_logging],
 )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.getLogger().addHandler(logging.NullHandler())
     admin_external.handle(
         endpoint,

--- a/tests/integration/demo/package/bin/demo_rh_settings.py
+++ b/tests/integration/demo/package/bin/demo_rh_settings.py
@@ -1,0 +1,46 @@
+
+import import_declare_test
+
+from splunktaucclib.rest_handler.endpoint import (
+    field,
+    validator,
+    RestModel,
+    MultipleModel,
+)
+from splunktaucclib.rest_handler import admin_external, util
+from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
+import logging
+
+util.remove_http_proxy_env_vars()
+
+
+special_fields = [
+
+]
+
+fields_logging = [
+    field.RestField(
+        'loglevel',
+        required=True,
+        encrypted=False,
+        default='INFO',
+        validator=None
+    )
+]
+model_logging = RestModel(fields_logging, name='logging', special_fields=special_fields)
+
+
+endpoint = MultipleModel(
+    'demo_settings',
+    models=[
+        model_logging
+    ],
+)
+
+
+if __name__ == '__main__':
+    logging.getLogger().addHandler(logging.NullHandler())
+    admin_external.handle(
+        endpoint,
+        handler=AdminExternalHandler,
+    )

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -146,7 +146,7 @@ for field Name\',)". See splunkd.log/python.log for more details.</msg>"""
     [
         "ftestname",
         "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnamet"
-        "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto"
+        "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto",
     ],
 )
 def test_custom_name_validation(value):
@@ -164,7 +164,7 @@ def test_custom_name_validation(value):
     )
 
     if value.startswith("toolongname"):
-        assert ('String length should be between 1 and 100' in response.text)
+        assert "String length should be between 1 and 100" in response.text
     else:
         assert expected_msg.replace("\n", "") in response.text
         assert response.status_code == 500

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -18,6 +18,8 @@ from requests.auth import HTTPBasicAuth
 import requests
 import os
 
+import pytest
+
 admin = os.getenv("SPLUNK_ADMIN")
 admin_password = os.getenv("SPLUNK_ADMIN_PWD")
 user = os.getenv("SPLUNK_USER")
@@ -75,13 +77,50 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
-        data={"name": "test12", "interval": "5"},
+        data={"name": "test22331", "interval": "a4"},
         headers={
             "accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
         },
-        auth=HTTPBasicAuth(user, user_password),
+        auth=HTTPBasicAuth(admin, admin_password),
         verify=False,
     )
     assert expected_msg.replace("\n", "") in response.text
     assert response.status_code == 500
+
+@pytest.mark.parametrize(
+    "value",
+    ["test[name", "test*name", "test\\name", "test]name", "test(name", "test)name", "test?name", "test:name",
+     "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnamet"
+     "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto"
+     "olongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoo"
+     "longnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametool"
+     "ongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolo"
+     "ngnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolon"
+     "gnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolong"
+     "nametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongn"
+     "ametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongna"
+     "metoolongnametoolongnamet"]
+)
+def test_basic_name_validation(value):
+    expected_msg = """<msg type="ERROR">Unexpected error "&lt;class 'splunktaucclib.rest_handler.error.RestError'&gt;" 
+from python handler: "REST Error [400]: Bad Request -- (\'"default", ".", "..", string started with "_" 
+and string including any one of ["*", "\\\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot be used 
+for field Name\',)". See splunkd.log/python.log for more details.</msg>"""
+
+    response = requests.post(
+        f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
+        data={"name": value, "interval": "44"},
+        headers={
+            "accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        auth=HTTPBasicAuth(admin, admin_password),
+        verify=False,
+    )
+
+    if value.startswith("toolongname"):
+        assert "<msg type=\"ERROR\">Parameter \"name\" must be less than 1024".replace("\n", "") in response.text
+    else:
+        assert expected_msg.replace("\n", "") in response.text
+        assert response.status_code == 500

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -77,12 +77,12 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
-        data={"name": "test22331", "interval": "a4"},
+        data={"name": "test12", "interval": "5"},
         headers={
             "accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
         },
-        auth=HTTPBasicAuth(admin, admin_password),
+        auth=HTTPBasicAuth(user, user_password),
         verify=False,
     )
     assert expected_msg.replace("\n", "") in response.text

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -160,7 +160,7 @@ def test_basic_name_validation_too_long_name():
 
 
 def test_custom_name_validation_invalid_name():
-    value = "atestname"
+    value = "testname"
     expected_msg = """All of the following errors need to be fixed: ["Not matching the pattern: ^[a-dA-D]\\\\w*$"]"""
 
     response = requests.post(

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -19,10 +19,8 @@ from splunktaucclib.rest_handler.handler import BASIC_NAME_VALIDATORS
 import requests
 import os
 
-import pytest
-
-admin = "admin"
-admin_password = "Chang3d!"
+admin = os.getenv("SPLUNK_ADMIN")
+admin_password = os.getenv("SPLUNK_ADMIN_PWD")
 user = os.getenv("SPLUNK_USER")
 user_password = os.getenv("SPLUNK_USER_PWD")
 host = "localhost"

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -139,3 +139,32 @@ for field Name\',)". See splunkd.log/python.log for more details.</msg>"""
     else:
         assert expected_msg.replace("\n", "") in response.text
         assert response.status_code == 500
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ftestname",
+        "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnamet"
+        "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto"
+    ],
+)
+def test_custom_name_validation(value):
+    expected_msg = """All of the following errors need to be fixed: ["Not matching the pattern: ^[a-dA-D]\\\\w*$"]"""
+
+    response = requests.post(
+        f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
+        data={"name": value, "interval": "44"},
+        headers={
+            "accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        auth=HTTPBasicAuth(admin, admin_password),
+        verify=False,
+    )
+
+    if value.startswith("toolongname"):
+        assert ('String length should be between 1 and 100' in response.text)
+    else:
+        assert expected_msg.replace("\n", "") in response.text
+        assert response.status_code == 500

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -77,7 +77,7 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
-        data={"name": "test12", "interval": "5"},
+        data={"name": "atest12", "interval": "5"},
         headers={
             "accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -19,6 +19,8 @@ from splunktaucclib.rest_handler.handler import BASIC_NAME_VALIDATORS
 import requests
 import os
 
+import pytest
+
 admin = os.getenv("SPLUNK_ADMIN")
 admin_password = os.getenv("SPLUNK_ADMIN_PWD")
 user = os.getenv("SPLUNK_USER")

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -88,19 +88,29 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
     assert expected_msg.replace("\n", "") in response.text
     assert response.status_code == 500
 
+
 @pytest.mark.parametrize(
     "value",
-    ["test[name", "test*name", "test\\name", "test]name", "test(name", "test)name", "test?name", "test:name",
-     "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnamet"
-     "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto"
-     "olongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoo"
-     "longnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametool"
-     "ongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolo"
-     "ngnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolon"
-     "gnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolong"
-     "nametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongn"
-     "ametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongna"
-     "metoolongnametoolongnamet"]
+    [
+        "test[name",
+        "test*name",
+        "test\\name",
+        "test]name",
+        "test(name",
+        "test)name",
+        "test?name",
+        "test:name",
+        "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnamet"
+        "oolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnameto"
+        "olongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoo"
+        "longnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametool"
+        "ongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolo"
+        "ngnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolon"
+        "gnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolong"
+        "nametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongn"
+        "ametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongna"
+        "metoolongnametoolongnamet",
+    ],
 )
 def test_basic_name_validation(value):
     expected_msg = """<msg type="ERROR">Unexpected error "&lt;class 'splunktaucclib.rest_handler.error.RestError'&gt;" 
@@ -120,7 +130,12 @@ for field Name\',)". See splunkd.log/python.log for more details.</msg>"""
     )
 
     if value.startswith("toolongname"):
-        assert "<msg type=\"ERROR\">Parameter \"name\" must be less than 1024".replace("\n", "") in response.text
+        assert (
+            '<msg type="ERROR">Parameter "name" must be less than 1024'.replace(
+                "\n", ""
+            )
+            in response.text
+        )
     else:
         assert expected_msg.replace("\n", "") in response.text
         assert response.status_code == 500

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -113,10 +113,10 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
     ],
 )
 def test_basic_name_validation(value):
-    expected_msg = """<msg type="ERROR">Unexpected error "&lt;class 'splunktaucclib.rest_handler.error.RestError'&gt;" 
-from python handler: "REST Error [400]: Bad Request -- (\'"default", ".", "..", string started with "_" 
-and string including any one of ["*", "\\\\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot be used 
-for field Name\',)". See splunkd.log/python.log for more details.</msg>"""
+    prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
+    prohibited_names = ["default", ".", ".."]
+    expected_msg = (f'{prohibited_names}, string started with "_" and string including any one '
+                   f'of {prohibited_chars} are reserved value which cannot be used for field Name"')
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -115,8 +115,10 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
 def test_basic_name_validation(value):
     prohibited_chars = ["*", "\\", "[", "]", "(", ")", "?", ":"]
     prohibited_names = ["default", ".", ".."]
-    expected_msg = (f'{prohibited_names}, string started with "_" and string including any one '
-                   f'of {prohibited_chars} are reserved value which cannot be used for field Name"')
+    expected_msg = (
+        f'{prohibited_names}, string started with "_" and string including any one '
+        f'of {prohibited_chars} are reserved value which cannot be used for field Name"'
+    )
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -100,7 +100,7 @@ from python handler: "REST Error [403]: Forbidden -- This operation is forbidden
         "test(name",
         "test)name",
         "test?name",
-        "test:name"
+        "test:name",
     ],
 )
 def test_basic_name_validation_prohibited_char_and_names(value):
@@ -127,17 +127,21 @@ def test_basic_name_validation_prohibited_char_and_names(value):
 
 
 def test_basic_name_validation_too_long_name():
-    value = ("toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnamet"),
+    value = (
+        (
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+            "toolongnametoolongnametoolongnamet"
+        ),
+    )
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",
@@ -150,10 +154,8 @@ def test_basic_name_validation_too_long_name():
         verify=False,
     )
     assert (
-            '<msg type="ERROR">Parameter "name" must be less than 1024'.replace(
-                "\n", ""
-            )
-            in response.text
+        '<msg type="ERROR">Parameter "name" must be less than 1024'.replace("\n", "")
+        in response.text
     )
 
 
@@ -176,9 +178,11 @@ def test_custom_name_validation_invalid_name():
 
 
 def test_custom_name_validation_too_long_name():
-    value = ("toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
-             "toolongnametoolongnameto")
+    value = (
+        "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+        "toolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongnametoolongname"
+        "toolongnametoolongnameto"
+    )
 
     response = requests.post(
         f"https://{host}:{management_port}/servicesNS/-/demo/demo_demo",


### PR DESCRIPTION
**Issue number:[ADDON-74237](https://splunk.atlassian.net/browse/ADDON-74237)**

## Summary

Added support for default and custom name field validation

### Changes

* RestModel now has an additional parameter "special_fields"
* RestEndpoint now has two additional methods for executing custom validations
* _pre_request decorator has new method "basic_name_validation" for basic validations

### User experience

Name field will be validated on the server side

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
