### PR TITLE
fix: import codecs

### DIFF
--- a/splunktaucclib/cim_actions.py
+++ b/splunktaucclib/cim_actions.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import codecs
 import collections
 import csv
 


### PR DESCRIPTION
[Issue-323](https://github.com/splunk/addonfactory-ucc-library/issues/323)

Imported `codecs` module for the addinfo method of ModularAction in `cim_actions.py` file.