### PR TITLE
fix: require splunk-sdk at least 2.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -745,4 +745,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "dbaf816ec3621d2b3e6653b8b26ac4e3f0157db15dd1b8a5e17cc55ce1a438a2"
+content-hash = "a7097c26c78f09162b3669cac1f3e8450c3a1ad6758e38a970cbc99c799a5005"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ splunktalib = "^3.0.4"
 requests = "^2.31.0"
 urllib3 = "<2"
 PySocks = "^1.7.1"
-splunk-sdk = ">=1.6"
+splunk-sdk = ">=2.0.2"
 solnlib = "^5.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Jira: https://splunk.atlassian.net/browse/ADDON-77054

This PR makes sure that `splunktaucclib` will require at least `2.0.2` version of `splunk-sdk`.