### PR TITLE
fix: allow solnlib from 5.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -745,4 +745,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "a7097c26c78f09162b3669cac1f3e8450c3a1ad6758e38a970cbc99c799a5005"
+content-hash = "07ab83d531614002e1a7af8cf175434263a4f34d6f05997b846b8788c94e8ef8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requests = "^2.31.0"
 urllib3 = "<2"
 PySocks = "^1.7.1"
 splunk-sdk = ">=2.0.2"
-solnlib = "^5.0.0"
+solnlib = ">=5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"


### PR DESCRIPTION
This PR allows to install both `splunktaucclib` and `solnlib` in the same env.

![image](https://github.com/user-attachments/assets/f89fa4e3-f552-40bb-9eea-129c5aaedb1a)
