### PR TITLE
feat: allow enabling and disabling of reloads

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,112 +35,114 @@ tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
-    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
+    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
+    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.3.2"
+version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.7"
 files = [
-    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
-    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f"},
+    {file = "charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b"},
+    {file = "charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35"},
+    {file = "charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407"},
+    {file = "charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-win32.whl", hash = "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487"},
+    {file = "charset_normalizer-3.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-win32.whl", hash = "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e"},
+    {file = "charset_normalizer-3.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-win32.whl", hash = "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5"},
+    {file = "charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765"},
+    {file = "charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"},
+    {file = "charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3"},
 ]
 
 [[package]]
@@ -181,13 +183,13 @@ packaging = "*"
 
 [[package]]
 name = "dunamai"
-version = "1.22.0"
+version = "1.23.0"
 description = "Dynamic version generation"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "dunamai-1.22.0-py3-none-any.whl", hash = "sha256:eab3894b31e145bd028a74b13491c57db01986a7510482c9b5fff3b4e53d77b7"},
-    {file = "dunamai-1.22.0.tar.gz", hash = "sha256:375a0b21309336f0d8b6bbaea3e038c36f462318c68795166e31f9873fdad676"},
+    {file = "dunamai-1.23.0-py3-none-any.whl", hash = "sha256:a0906d876e92441793c6a423e16a4802752e723e9c9a5aabdc5535df02dbe041"},
+    {file = "dunamai-1.23.0.tar.gz", hash = "sha256:a163746de7ea5acb6dacdab3a6ad621ebc612ed1e528aaa8beedb8887fccd2c4"},
 ]
 
 [package.dependencies]
@@ -221,14 +223,17 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -281,13 +286,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [package.dependencies]
@@ -597,21 +602,19 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "solnlib"
-version = "5.4.0"
+version = "6.1.0"
 description = "The Splunk Software Development Kit for Splunk Solutions"
 optional = false
-python-versions = "<4.0,>=3.7"
+python-versions = "<3.14,>=3.7"
 files = [
-    {file = "solnlib-5.4.0-py3-none-any.whl", hash = "sha256:bf02fb9e6148644d74500b22a0a34996e047ef4ffd04caf21eb4eeca60c4f48d"},
-    {file = "solnlib-5.4.0.tar.gz", hash = "sha256:592349501b5482b2722f7600498c80e03d807b6ff6bcf797b89ea06b48f05b8f"},
+    {file = "solnlib-6.1.0-py3-none-any.whl", hash = "sha256:49f55e663ccd2dc0927989123f9ea06f432e52d165738ceabdf91337bfc3f785"},
+    {file = "solnlib-6.1.0.tar.gz", hash = "sha256:4d69741f029b18ffa5f099b88e1220d3b4b735e452090119cdc766476d770a81"},
 ]
 
 [package.dependencies]
 defusedxml = ">=0.7"
-requests = ">=2.31.0,<3.0.0"
 sortedcontainers = ">=2"
-splunk-sdk = ">=1.6"
-urllib3 = "<2"
+splunk-sdk = ">=2.0.2"
 
 [[package]]
 name = "sortedcontainers"
@@ -626,13 +629,13 @@ files = [
 
 [[package]]
 name = "splunk-add-on-ucc-framework"
-version = "5.52.0"
+version = "5.57.0"
 description = "Splunk Add-on SDK formerly UCC is a build and code generation framework"
 optional = false
-python-versions = "<4.0,>=3.7"
+python-versions = "<3.14,>=3.7"
 files = [
-    {file = "splunk_add_on_ucc_framework-5.52.0-py3-none-any.whl", hash = "sha256:2271feec0dac748716540a7e3b694ce9b224d48c8d4fa4f076103a649fbe2e34"},
-    {file = "splunk_add_on_ucc_framework-5.52.0.tar.gz", hash = "sha256:ea722bacfcff3d4531fd16dbd1cc09610e1ad2bee769931288df3b34db6a2066"},
+    {file = "splunk_add_on_ucc_framework-5.57.0-py3-none-any.whl", hash = "sha256:c93e85ec486db9dd45bb7d044c0beac639ac6051890bd9579800ea3f608a79d3"},
+    {file = "splunk_add_on_ucc_framework-5.57.0.tar.gz", hash = "sha256:83c08b7a28a030060fb966c3a535a01db12d5c6c42017d6e5e3f99b5b65e63cb"},
 ]
 
 [package.dependencies]
@@ -642,7 +645,7 @@ defusedxml = ">=0.7.1,<0.8.0"
 dunamai = ">=1.22.0,<2.0.0"
 jinja2 = ">=2,<4"
 jsonschema = ">=4.4.0,<5.0.0"
-packaging = "24.0"
+packaging = ">=23.0"
 PyYAML = ">=6.0,<7.0"
 
 [[package]]
@@ -744,5 +747,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "07ab83d531614002e1a7af8cf175434263a4f34d6f05997b846b8788c94e8ef8"
+python-versions = ">=3.7,<3.14"
+content-hash = "483166975e10a81a9c5cd005e6f316c2f3e1f4bf9c313d13dd4e3f74511b84d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ solnlib = ">=5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"
-splunk-add-on-ucc-framework = ">=5.57.0"
+splunk-add-on-ucc-framework = ">=5.53.0"
 splunk-packaging-toolkit = ">=1"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = ["Splunk <addonfactory@splunk.com>"]
 license = "APACHE-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<3.14"
 splunktalib = "^3.0.4"
 requests = "^2.31.0"
 urllib3 = "<2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ solnlib = ">=5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"
-splunk-add-on-ucc-framework = ">=5"
+splunk-add-on-ucc-framework = ">=5.57.0"
 splunk-packaging-toolkit = ">=1"
 
 [build-system]

--- a/splunktaucclib/rest_handler/endpoint/__init__.py
+++ b/splunktaucclib/rest_handler/endpoint/__init__.py
@@ -115,7 +115,7 @@ class SingleModel(RestEndpoint):
         model,
         user="nobody",
         app=None,
-        need_reload=True,
+        need_reload=False,
         *args,
         **kwargs,
     ):
@@ -153,7 +153,7 @@ class MultipleModel(RestEndpoint):
         models,
         user="nobody",
         app=None,
-        need_reload=True,
+        need_reload=False,
         *args,
         **kwargs,
     ):

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -315,7 +315,7 @@ class RestHandler:
         need_reload = self._is_reload_needed(f"config:{name}")
 
         if need_reload is None:
-            need_reload = self._is_reload_needed("default")
+            need_reload = self._is_reload_needed("config")
 
         if need_reload is None:
             need_reload = self._endpoint.need_reload
@@ -323,18 +323,18 @@ class RestHandler:
         return need_reload
 
     def _is_reload_needed(self, name: str) -> Optional[bool]:
-        response = self._client.get(
-            self.path_segment(
-                _TA_CONFIG_ENDPOINT,
-                name=name,
-            ),
-            output_mode="json",
-        )
-
-        if not _is_status_ok(response.status):
+        try:
+            response = self._client.get(
+                self.path_segment(
+                    _TA_CONFIG_ENDPOINT,
+                    name=name,
+                ),
+                output_mode="json",
+            )
+        except binding.HTTPError:
             return None
 
-        response = json.loads(response.body.read())
+        response = json.loads(response["body"].read())
 
         if "entry" in response:
             for entry in response["entry"]:
@@ -528,10 +528,6 @@ class RestHandler:
                     and model["content"][field_name] != ""
                 ):
                     model["content"][field_name] = self.PASSWORD
-
-
-def _is_status_ok(status: int):
-    return 200 <= status < 300
 
 
 def _convert_to_boolean(value: Optional[Any]) -> Optional[bool]:

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -312,17 +312,15 @@ class RestHandler:
             self.reload()
 
     def is_reload_needed(self, name: str) -> bool:
-        need_reload = self._is_reload_needed(f"config:{name}")
-
-        if need_reload is None:
-            need_reload = self._is_reload_needed("config")
+        need_reload = self._is_reload_needed()
 
         if need_reload is None:
             need_reload = self._endpoint.need_reload
 
         return need_reload
 
-    def _is_reload_needed(self, name: str) -> Optional[bool]:
+    def _is_reload_needed(self) -> Optional[bool]:
+        name = "config"
         try:
             response = self._client.get(
                 self.path_segment(

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -43,7 +43,7 @@ BASIC_NAME_VALIDATORS = {
     "MAX_LENGTH": 1024,
 }
 
-_TA_CONFIG_FILENAME = "!TA_config"
+_TA_CONFIG_FILENAME = "_TA_config"
 _TA_CONFIG_ENDPOINT = f"configs/conf-{_TA_CONFIG_FILENAME}"
 _NEED_RELOAD_PARAMETER = "need_reload"
 
@@ -334,7 +334,7 @@ class RestHandler:
         except binding.HTTPError:
             return None
 
-        response = json.loads(response["body"].read())
+        response = json.loads(response.body.read())
 
         if "entry" in response:
             for entry in response["entry"]:

--- a/splunktaucclib/rest_handler/handler.py
+++ b/splunktaucclib/rest_handler/handler.py
@@ -308,10 +308,10 @@ class RestHandler:
         return self._flay_response(response)
 
     def reload_if_needed(self):
-        if self._conf_name and self.is_reload_needed(self._conf_name):
+        if self._conf_name and self.is_reload_needed():
             self.reload()
 
-    def is_reload_needed(self, name: str) -> bool:
+    def is_reload_needed(self) -> bool:
         need_reload = self._is_reload_needed()
 
         if need_reload is None:

--- a/tests/integration/demo/additional_packaging.py
+++ b/tests/integration/demo/additional_packaging.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from textwrap import dedent
+
+
+def cleanup_output_files(output_path: str, ta_name: str) -> None:
+    """Helper function used by UCC. It is here used to register a new handler not defined in the globalConfig."""
+    web_conf = Path(output_path) / ta_name / "default" / "web.conf"
+    restmap_conf = Path(output_path) / ta_name / "default" / "restmap.conf"
+
+    assert web_conf.exists()
+    assert restmap_conf.exists()
+
+    web_conf.write_text(
+        web_conf.read_text()
+        + dedent(
+            """
+            [expose:demo_test_reload_override]
+            pattern = demo_test_reload_override
+            methods = POST, GET
+
+            [expose:demo_test_reload_override_specified]
+            pattern = demo_test_reload_override/*
+            methods = POST, GET, DELETE
+            """
+        )
+    )
+
+    restmap_conf.write_text(
+        restmap_conf.read_text().replace(
+            "members =", "members = demo_test_reload_override,"
+        )
+        + dedent(
+            """
+            [admin_external:demo_test_reload_override]
+            handlertype = python
+            python.version = python3
+            handlerfile = demo_rh_test_reload_override.py
+            handleractions = create, edit, list, remove
+            handlerpersistentmode = true
+            """
+        )
+    )

--- a/tests/integration/demo/package/bin/demo_rh_test_reload_override.py
+++ b/tests/integration/demo/package/bin/demo_rh_test_reload_override.py
@@ -18,6 +18,7 @@ model = RestModel(fields_logging, name=None, special_fields=special_fields)
 endpoint = SingleModel(
     "demo_test_reload_override",
     model=model,
+    need_reload=True,
 )
 
 

--- a/tests/integration/demo/package/bin/demo_rh_test_reload_override.py
+++ b/tests/integration/demo/package/bin/demo_rh_test_reload_override.py
@@ -1,0 +1,29 @@
+import import_declare_test
+
+from splunktaucclib.rest_handler.endpoint import (
+    RestModel,
+    SingleModel,
+)
+from splunktaucclib.rest_handler import admin_external, util
+from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
+import logging
+
+util.remove_http_proxy_env_vars()
+
+
+special_fields = []
+fields_logging = []
+model = RestModel(fields_logging, name=None, special_fields=special_fields)
+
+endpoint = SingleModel(
+    "demo_test_reload_override",
+    model=model,
+)
+
+
+if __name__ == "__main__":
+    logging.getLogger().addHandler(logging.NullHandler())
+    admin_external.handle(
+        endpoint,
+        handler=AdminExternalHandler,
+    )

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from datetime import datetime
 from urllib import parse
 from requests.auth import HTTPBasicAuth
 from splunktaucclib.rest_handler.handler import BASIC_NAME_VALIDATORS

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -281,12 +281,10 @@ def test_reload_override():
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override/_reload",
             "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
-            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
             "/servicesNS/-/demo/demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override/_reload",
             "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
-            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
             "/servicesNS/-/demo/demo_test_reload_override",
         ],
     )
@@ -308,11 +306,9 @@ def test_reload_override():
         [
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
-            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
             "/servicesNS/-/demo/demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
             "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
-            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
             "/servicesNS/-/demo/demo_test_reload_override",
         ],
     )

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from datetime import datetime
 from urllib import parse
 from requests.auth import HTTPBasicAuth
 from splunktaucclib.rest_handler.handler import BASIC_NAME_VALIDATORS

--- a/tests/integration/test_rest_handler_handler.py
+++ b/tests/integration/test_rest_handler_handler.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from datetime import datetime
+from time import sleep
+from typing import List, Any
 from urllib import parse
 from requests.auth import HTTPBasicAuth
 from splunktaucclib.rest_handler.handler import BASIC_NAME_VALIDATORS
@@ -195,3 +198,142 @@ def test_custom_name_validation_too_long_name():
         verify=False,
     )
     assert "String length should be between 1 and 100" in response.text
+
+
+def test_reload_override():
+    def switch_reloads(enabled=None):
+        try:
+            requests.delete(
+                f"https://{host}:{management_port}/servicesNS/nobody/demo/configs/conf-_TA_config/config?output_mode=json",
+                headers={
+                    "accept": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                auth=HTTPBasicAuth(admin, admin_password),
+                verify=False,
+            )
+        except:
+            pass
+
+        if enabled is None:
+            return
+
+        response = requests.post(
+            f"https://{host}:{management_port}/servicesNS/nobody/demo/configs/conf-_TA_config?output_mode=json",
+            data={
+                "name": "config",
+                "need_reload": "1" if enabled else "0",
+            },
+            headers={
+                "accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            auth=HTTPBasicAuth(admin, admin_password),
+            verify=False,
+        )
+
+        assert response.ok, response.json()
+
+    def call():
+        response = requests.get(
+            f"https://{host}:{management_port}/servicesNS/-/demo/demo_test_reload_override?output_mode=json",
+            headers={
+                "accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            auth=HTTPBasicAuth(admin, admin_password),
+            verify=False,
+        )
+
+        assert response.status_code == 200
+
+    def search_uris(earliest, latest):
+        result = search(
+            "search index=_internal AND uri_path=*/demo/* AND NOT uri_path=*services/search* "
+            "AND (uri_path=*demo_test_reload_override* OR uri_path=*TA_config*)",
+            earliest,
+            latest,
+        )
+        return [res["uri_path"] for res in result if "GET" in res["_raw"]]
+
+    def assert_search(earliest, latest, expected):
+        for i in range(50):
+            if search_uris(earliest, latest) == expected:
+                return True
+            sleep(0.1)
+        else:
+            assert search_uris(earliest, latest) == expected
+
+    # make sure nothing is set
+    switch_reloads()
+
+    earliest = int(datetime.now().timestamp())
+
+    for _ in range(2):
+        call()
+
+    latest = int(datetime.now().timestamp()) + 1
+
+    assert assert_search(
+        earliest,
+        latest,
+        [
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override/_reload",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
+            "/servicesNS/-/demo/demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override/_reload",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
+            "/servicesNS/-/demo/demo_test_reload_override",
+        ],
+    )
+
+    # disable reloads
+    switch_reloads(False)
+
+    earliest = int(datetime.now().timestamp())
+
+    for _ in range(2):
+        call()
+
+    latest = int(datetime.now().timestamp()) + 1
+
+    # same as above, but without the reloads
+    assert assert_search(
+        earliest,
+        latest,
+        [
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
+            "/servicesNS/-/demo/demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-demo_test_reload_override",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config",
+            "/servicesNS/nobody/demo/configs/conf-_TA_config/config%3Ademo_test_reload_override",
+            "/servicesNS/-/demo/demo_test_reload_override",
+        ],
+    )
+
+
+def search(query: str, earliest_time: int, latest_time: int) -> List[Any]:
+    response = requests.post(
+        f"https://{host}:{management_port}/servicesNS/admin/demo/search/jobs?output_mode=json",
+        data={
+            "search": query,
+            "earliest_time": earliest_time,
+            "latest_time": latest_time,
+            "exec_mode": "oneshot",
+            "enable_lookups": "0",
+        },
+        headers={
+            "accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        auth=HTTPBasicAuth(admin, admin_password),
+        verify=False,
+    )
+
+    return response.json()["results"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.unit.fake_module import mock_splunk_module
+
+
+mock_splunk_module()
+
+
+@pytest.fixture
+def admin(monkeypatch) -> MagicMock:
+    from splunktaucclib.rest_handler import admin_external
+
+    new_admin = mock_splunk_module()
+    monkeypatch.setattr(admin_external, "admin", new_admin)
+
+    return new_admin
+
+
+@pytest.fixture
+def client_mock():
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def setup(monkeypatch, client_mock):
+    from splunktaucclib.rest_handler import credentials
+    from splunktaucclib.rest_handler import handler
+
+    monkeypatch.setitem(os.environ, "SPLUNKD_URI", "https://localhost:1234")
+    monkeypatch.setattr(credentials, "get_base_app_name", lambda: "splunk_ta_test")
+    monkeypatch.setattr(
+        handler, "SplunkRestClient", MagicMock(return_value=client_mock)
+    )

--- a/tests/unit/fake_module.py
+++ b/tests/unit/fake_module.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from collections import namedtuple
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+
+CallerArgs = namedtuple("CallerArgs", ["id", "data"])
+
+ACTION_LIST = 0
+ACTION_REMOVE = 1
+ACTION_CREATE = 2
+ACTION_EDIT = 3
+
+
+class MConfigHandler:
+    def __init__(self, action: int, caller_args: CallerArgs):
+        self.requestedAction = action
+        self.callerArgs = caller_args
+
+    def handleList(self, confInfo: Any):
+        raise NotImplementedError()
+
+    def handleCreate(self, confInfo: Any):
+        raise NotImplementedError()
+
+    def handleEdit(self, confInfo: Any):
+        raise NotImplementedError()
+
+    def handleRemove(self, confInfo: Any):
+        raise NotImplementedError()
+
+    def getSessionKey(self):
+        return "abcd"
+
+    @classmethod
+    def get(cls, name: Optional[str] = None):
+        return cls(ACTION_LIST, CallerArgs(name, {})).handleList(MagicMock())
+
+
+def mock_splunk_module() -> MagicMock:
+    sys.modules["splunk"] = types.ModuleType("splunk")
+
+    admin = MagicMock()
+    sys.modules["splunk.admin"] = admin
+
+    admin.MConfigHandler = MConfigHandler
+
+    for action in ("ACTION_LIST", "ACTION_REMOVE", "ACTION_CREATE", "ACTION_EDIT"):
+        setattr(admin, action, globals()[action])
+
+    return admin

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -64,41 +64,32 @@ def test_handle_single_model_reload(admin, client_mock, need_reload, cls, monkey
         handler.get()
 
     if need_reload:
-        assert client_mock.get.call_count == 12
+        assert client_mock.get.call_count == 9
         assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
     else:
-        assert client_mock.get.call_count == 9
+        assert client_mock.get.call_count == 6
         assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
         ]
 
 
 @pytest.mark.parametrize("override", [True, False])
-@pytest.mark.parametrize("override_location", ["config", "config:demo_reload"])
-def test_handle_single_model_reload_override(
-    admin, client_mock, monkeypatch, override, override_location
-):
+def test_handle_single_model_reload_override(admin, client_mock, monkeypatch, override):
     def _get(path, *args, **kwargs):
         _get.call_count += 1
         _get.paths.append(path)
@@ -107,9 +98,9 @@ def test_handle_single_model_reload_override(
         value = {"key": "value"}
         name = "test"
 
-        if path == f"configs/conf-_TA_config/{override_location}":
+        if path == f"configs/conf-_TA_config/config":
             value = {"need_reload": override}
-            name = override_location
+            name = "config"
         elif path.startswith("configs/conf-_TA_config"):
             status = 404
 
@@ -141,46 +132,22 @@ def test_handle_single_model_reload_override(
     for _ in range(2):
         handler.get()
 
-    if override and override_location == "config":
-        assert client_mock.get.call_count == 8
-        assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
-            "configs/conf-_TA_config/config",
-            "configs/conf-demo_reload/_reload",
-            "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
-            "configs/conf-_TA_config/config",
-            "configs/conf-demo_reload/_reload",
-            "configs/conf-demo_reload",
-        ]
-
-    if not override and override_location == "config":
-        # assert client_mock.get.call_count == 6
-        assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
-            "configs/conf-_TA_config/config",
-            "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
-            "configs/conf-_TA_config/config",
-            "configs/conf-demo_reload",
-        ]
-
-    if override and override_location != "config":
+    if override:
         assert client_mock.get.call_count == 6
         assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
 
-    if not override and override_location != "config":
+    if not override:
         assert client_mock.get.call_count == 4
         assert client_mock.get.paths == [
-            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
-            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
         ]

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from io import StringIO
 
 import pytest
-from solnlib.server_info import ServerInfo
 
 from splunktaucclib.rest_handler import admin_external
 from splunktaucclib.rest_handler.admin_external import AdminExternalHandler

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -1,0 +1,89 @@
+import json
+from collections import namedtuple
+from io import StringIO
+
+import pytest
+from solnlib.server_info import ServerInfo
+
+from splunktaucclib.rest_handler import admin_external
+from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
+from splunktaucclib.rest_handler.endpoint import RestModel, SingleModel, MultipleModel
+
+Response = namedtuple("Response", ["body"])
+
+
+def eai_response(value):
+    return Response(
+        body=StringIO(
+            json.dumps({"entry": [{"content": value, "name": "test", "acl": "acl"}]})
+        )
+    )
+
+
+@pytest.mark.parametrize("need_reload", [True, False])
+@pytest.mark.parametrize("is_cloud", [True, False])
+@pytest.mark.parametrize("cls", [SingleModel, MultipleModel])
+def test_handle_single_model_reload(
+    admin, client_mock, need_reload, cls, is_cloud, monkeypatch
+):
+    def is_cloud_instance(self):
+        return is_cloud
+
+    monkeypatch.setattr(ServerInfo, "is_cloud_instance", is_cloud_instance)
+
+    model = RestModel([], name=None, special_fields=[])
+
+    if cls is MultipleModel:
+        model = [model, RestModel([], name="test", special_fields=[])]
+
+    endpoint = cls(
+        "demo_reload",
+        model,
+        app="fake_app",
+        need_reload=need_reload,
+    )
+
+    admin_external.handle(
+        endpoint,
+        handler=AdminExternalHandler,
+    )
+
+    assert admin.init.call_count == 1
+
+    client_mock.get.return_value = eai_response({"key": "value"})
+
+    handler: AdminExternalHandler = admin.init.call_args[0][0]
+
+    for _ in range(3):
+        client_mock.get.return_value = eai_response({"key": "value"})
+        handler.get()
+
+    if need_reload:
+        # if is_cloud:
+        #     assert client_mock.get.call_count == 4
+        #     assert [i.args[0] for i in client_mock.get.call_args_list] == [
+        #         "services/server/info",
+        #         "configs/conf-demo_reload",
+        #         "configs/conf-demo_reload",
+        #         "configs/conf-demo_reload",
+        #     ]
+        # else:
+        #     ...
+
+        assert client_mock.get.call_count == 6
+        assert [i.args[0] for i in client_mock.get.call_args_list] == [
+            # "services/server/info",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+        ]
+    else:
+        assert client_mock.get.call_count == 3
+        assert [i.args[0] for i in client_mock.get.call_args_list] == [
+            "configs/conf-demo_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-demo_reload",
+        ]

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -21,16 +21,8 @@ def eai_response(value):
 
 
 @pytest.mark.parametrize("need_reload", [True, False])
-@pytest.mark.parametrize("is_cloud", [True, False])
 @pytest.mark.parametrize("cls", [SingleModel, MultipleModel])
-def test_handle_single_model_reload(
-    admin, client_mock, need_reload, cls, is_cloud, monkeypatch
-):
-    def is_cloud_instance(self):
-        return is_cloud
-
-    monkeypatch.setattr(ServerInfo, "is_cloud_instance", is_cloud_instance)
-
+def test_handle_single_model_reload(admin, client_mock, need_reload, cls):
     model = RestModel([], name=None, special_fields=[])
 
     if cls is MultipleModel:
@@ -59,20 +51,8 @@ def test_handle_single_model_reload(
         handler.get()
 
     if need_reload:
-        # if is_cloud:
-        #     assert client_mock.get.call_count == 4
-        #     assert [i[0][0] for i in client_mock.get.call_args_list] == [
-        #         "services/server/info",
-        #         "configs/conf-demo_reload",
-        #         "configs/conf-demo_reload",
-        #         "configs/conf-demo_reload",
-        #     ]
-        # else:
-        #     ...
-
         assert client_mock.get.call_count == 6
         assert [i[0][0] for i in client_mock.get.call_args_list] == [
-            # "services/server/info",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
             "configs/conf-demo_reload/_reload",

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -29,7 +29,7 @@ def test_handle_single_model_reload(admin, client_mock, need_reload, cls, monkey
 
         status = 200
 
-        if path.startswith("configs/conf-!TA_config"):
+        if path.startswith("configs/conf-_TA_config"):
             status = 404
 
         return eai_response({"key": "value"}, status)
@@ -66,36 +66,36 @@ def test_handle_single_model_reload(admin, client_mock, need_reload, cls, monkey
     if need_reload:
         assert client_mock.get.call_count == 12
         assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
     else:
         assert client_mock.get.call_count == 9
         assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload",
         ]
 
 
 @pytest.mark.parametrize("override", [True, False])
-@pytest.mark.parametrize("override_location", ["default", "config:demo_reload"])
+@pytest.mark.parametrize("override_location", ["config", "config:demo_reload"])
 def test_handle_single_model_reload_override(
     admin, client_mock, monkeypatch, override, override_location
 ):
@@ -107,10 +107,10 @@ def test_handle_single_model_reload_override(
         value = {"key": "value"}
         name = "test"
 
-        if path == f"configs/conf-!TA_config/{override_location}":
+        if path == f"configs/conf-_TA_config/{override_location}":
             value = {"need_reload": override}
             name = override_location
-        elif path.startswith("configs/conf-!TA_config"):
+        elif path.startswith("configs/conf-_TA_config"):
             status = 404
 
         return eai_response(value, status, name)
@@ -141,46 +141,46 @@ def test_handle_single_model_reload_override(
     for _ in range(2):
         handler.get()
 
-    if override and override_location == "default":
+    if override and override_location == "config":
         assert client_mock.get.call_count == 8
         assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
 
-    if not override and override_location == "default":
+    if not override and override_location == "config":
+        # assert client_mock.get.call_count == 6
+        assert client_mock.get.paths == [
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
+            "configs/conf-demo_reload",
+            "configs/conf-_TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config",
+            "configs/conf-demo_reload",
+        ]
+
+    if override and override_location != "config":
         assert client_mock.get.call_count == 6
         assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
-            "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
-            "configs/conf-!TA_config/default",
-            "configs/conf-demo_reload",
-        ]
-
-    if override and override_location != "default":
-        assert client_mock.get.call_count == 6
-        assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
 
-    if not override and override_location != "default":
+    if not override and override_location != "config":
         assert client_mock.get.call_count == 4
         assert client_mock.get.paths == [
-            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-demo_reload",
-            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-_TA_config/config:demo_reload",
             "configs/conf-demo_reload",
         ]

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -71,7 +71,7 @@ def test_handle_single_model_reload(
         #     ...
 
         assert client_mock.get.call_count == 6
-        assert [i.args[0] for i in client_mock.get.call_args_list] == [
+        assert [i[0][0] for i in client_mock.get.call_args_list] == [
             # "services/server/info",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -8,20 +8,37 @@ from splunktaucclib.rest_handler import admin_external
 from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
 from splunktaucclib.rest_handler.endpoint import RestModel, SingleModel, MultipleModel
 
-Response = namedtuple("Response", ["body"])
+Response = namedtuple("Response", ["body", "status"])
 
 
-def eai_response(value):
+def eai_response(value, status, name="test"):
     return Response(
         body=StringIO(
-            json.dumps({"entry": [{"content": value, "name": "test", "acl": "acl"}]})
-        )
+            json.dumps({"entry": [{"content": value, "name": name, "acl": "acl"}]})
+        ),
+        status=status,
     )
 
 
 @pytest.mark.parametrize("need_reload", [True, False])
 @pytest.mark.parametrize("cls", [SingleModel, MultipleModel])
-def test_handle_single_model_reload(admin, client_mock, need_reload, cls):
+def test_handle_single_model_reload(admin, client_mock, need_reload, cls, monkeypatch):
+    def _get(path, *args, **kwargs):
+        _get.call_count += 1
+        _get.paths.append(path)
+
+        status = 200
+
+        if path.startswith("configs/conf-!TA_config"):
+            status = 404
+
+        return eai_response({"key": "value"}, status)
+
+    _get.call_count = 0
+    _get.paths = []
+
+    monkeypatch.setattr(client_mock, "get", _get)
+
     model = RestModel([], name=None, special_fields=[])
 
     if cls is MultipleModel:
@@ -41,28 +58,129 @@ def test_handle_single_model_reload(admin, client_mock, need_reload, cls):
 
     assert admin.init.call_count == 1
 
-    client_mock.get.return_value = eai_response({"key": "value"})
-
     handler: AdminExternalHandler = admin.init.call_args[0][0]
 
     for _ in range(3):
-        client_mock.get.return_value = eai_response({"key": "value"})
         handler.get()
 
     if need_reload:
-        assert client_mock.get.call_count == 6
-        assert [i[0][0] for i in client_mock.get.call_args_list] == [
+        assert client_mock.get.call_count == 12
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
             "configs/conf-demo_reload/_reload",
             "configs/conf-demo_reload",
         ]
     else:
-        assert client_mock.get.call_count == 3
-        assert [i[0][0] for i in client_mock.get.call_args_list] == [
+        assert client_mock.get.call_count == 9
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
             "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
             "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
+            "configs/conf-demo_reload",
+        ]
+
+
+@pytest.mark.parametrize("override", [True, False])
+@pytest.mark.parametrize("override_location", ["default", "config:demo_reload"])
+def test_handle_single_model_reload_override(
+    admin, client_mock, monkeypatch, override, override_location
+):
+    def _get(path, *args, **kwargs):
+        _get.call_count += 1
+        _get.paths.append(path)
+
+        status = 200
+        value = {"key": "value"}
+        name = "test"
+
+        if path == f"configs/conf-!TA_config/{override_location}":
+            value = {"need_reload": override}
+            name = override_location
+        elif path.startswith("configs/conf-!TA_config"):
+            status = 404
+
+        return eai_response(value, status, name)
+
+    _get.call_count = 0
+    _get.paths = []
+
+    monkeypatch.setattr(client_mock, "get", _get)
+
+    model = RestModel([], name=None, special_fields=[])
+
+    endpoint = SingleModel(
+        "demo_reload",
+        model,
+        app="fake_app",
+        need_reload=True,
+    )
+
+    admin_external.handle(
+        endpoint,
+        handler=AdminExternalHandler,
+    )
+
+    assert admin.init.call_count == 1
+
+    handler: AdminExternalHandler = admin.init.call_args[0][0]
+
+    for _ in range(2):
+        handler.get()
+
+    if override and override_location == "default":
+        assert client_mock.get.call_count == 8
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+        ]
+
+    if not override and override_location == "default":
+        assert client_mock.get.call_count == 6
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
+            "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-!TA_config/default",
+            "configs/conf-demo_reload",
+        ]
+
+    if override and override_location != "default":
+        assert client_mock.get.call_count == 6
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-demo_reload/_reload",
+            "configs/conf-demo_reload",
+        ]
+
+    if not override and override_location != "default":
+        assert client_mock.get.call_count == 4
+        assert client_mock.get.paths == [
+            "configs/conf-!TA_config/config:demo_reload",
+            "configs/conf-demo_reload",
+            "configs/conf-!TA_config/config:demo_reload",
             "configs/conf-demo_reload",
         ]

--- a/tests/unit/test_admin_external.py
+++ b/tests/unit/test_admin_external.py
@@ -61,7 +61,7 @@ def test_handle_single_model_reload(
     if need_reload:
         # if is_cloud:
         #     assert client_mock.get.call_count == 4
-        #     assert [i.args[0] for i in client_mock.get.call_args_list] == [
+        #     assert [i[0][0] for i in client_mock.get.call_args_list] == [
         #         "services/server/info",
         #         "configs/conf-demo_reload",
         #         "configs/conf-demo_reload",
@@ -82,7 +82,7 @@ def test_handle_single_model_reload(
         ]
     else:
         assert client_mock.get.call_count == 3
-        assert [i.args[0] for i in client_mock.get.call_args_list] == [
+        assert [i[0][0] for i in client_mock.get.call_args_list] == [
             "configs/conf-demo_reload",
             "configs/conf-demo_reload",
             "configs/conf-demo_reload",


### PR DESCRIPTION
This change allows to enable or disable config file reloads in TA's.

This option is stored in `_TA_config.conf`.

Example content:

```
[config]
need_reload = 0
```

This example indicates, that we override default `need_reload` values to 0 (false).

Example usage:
POST call to:
`/servicesNS/-/APP_NAME/conf-_TA-config`
with parameters:
- `name`=`config`
- `need_reload`=`0`

or, if it already exists, an update (also POST) call to:
`/servicesNS/-/APP_NAME/conf-_TA-config/config`
with parameters:
- `need_reload`=`0`