### PR TITLE
feat(ADDON-88124): add IndexName validator for Splunk index name validation

### DIFF
--- a/splunktaucclib/rest_handler/endpoint/validator.py
+++ b/splunktaucclib/rest_handler/endpoint/validator.py
@@ -18,8 +18,8 @@
 Validators for Splunk configuration.
 """
 
-
 import json
+import os
 import re
 import warnings
 from inspect import isfunction
@@ -40,6 +40,7 @@ __all__ = [
     "Datetime",
     "Email",
     "JsonString",
+    "IndexName",
 ]
 
 
@@ -483,3 +484,248 @@ class JsonString(Validator):
             self.put_msg("Invalid JSON string")
             return False
         return True
+
+
+class IndexName(Validator):
+    """
+    Validates a Splunk index name by calling the Splunk core endpoint
+    POST /services/data/indexes/_validateName.
+
+    No arguments are required. The session key and splunkd URI are
+    resolved automatically from the running process context:
+    - session key from __main__.___sessionKey (set by MConfigHandler.__init__)
+    - splunkd URI from SPLUNKD_URI env var (set by AdminExternalHandler.__init__)
+
+    Falls back to local validation rules (mirroring IndexName::validate() in
+    IndexName.cpp) when the endpoint is not available on the running Splunk version.
+
+    Usage::
+
+    >>> from splunktaucclib.rest_handler.endpoint.field import RestField
+    >>> from splunktaucclib.rest_handler.endpoint.validator import IndexName
+    >>>
+    >>> RestField("index", required=True, validator=IndexName())
+
+    """
+
+    _ENDPOINT = "data/indexes/_validateName"
+    _INDEX_NAME_MAX_LEN = 2048
+    _DATASET_NAME_MAX_LEN = 1024
+    # Internal indexes from splcore develop branch IndexAdminHandler::validateName()
+    _INTERNAL_INDEXES = frozenset(
+        {
+            "_audit",
+            "help",
+            "history",
+            "_internal",
+            "sample",
+            "splunklogger",
+            "summary",
+            "_introspection",
+            "_thefishbucket",
+            "_telemetry",
+            "_metrics",
+            "_configtracker",
+            "_dsphonehome",
+            "_dsappevent",
+            "_dsclient",
+            "_cmc_summary",
+            "_metrics_rollup",
+            "_dm_summary",
+            "_dsevent_index_summary",
+        }
+    )
+    _VALID_CHARS = re.compile(r"^[0-9a-zA-Z_\-]+$")
+    _MSG_INDEX_NAME_NOT_SUPPORTED = (
+        'Argument "index_name" is not supported by this handler.'
+    )
+    # SplunkCore index services prefix — stripped before applying IndexName rules
+    _FEDERATED_INDEX_PREFIX = "federated:"
+    # MDL prefix — routes to dataset name validation instead
+    _FEDERATED_MDL_PREFIX = "~.federated."
+
+    @staticmethod
+    def _validate_as_index_name(name: str) -> str:
+        src = (
+            name[len(IndexName._FEDERATED_INDEX_PREFIX) :]
+            if name.startswith(IndexName._FEDERATED_INDEX_PREFIX)
+            else name
+        )
+        src_lower = src.lower()
+
+        if len(src) > IndexName._INDEX_NAME_MAX_LEN:
+            return f"Index name '{src}' is too long, please try a shorter name"
+
+        if not src:
+            return "Index name cannot be empty"
+
+        if src[0] == "-":
+            return f"Invalid index name: '{src}'. Index name cannot start with '-'"
+
+        if src[0] == "_" and src_lower not in IndexName._INTERNAL_INDEXES:
+            return f"Invalid index name: '{src}'. Index name cannot start with '_' unless it's one of reserved internal indexes: {', '.join(IndexName._INTERNAL_INDEXES)}"
+
+        if not IndexName._VALID_CHARS.match(src):
+            return f"Invalid index name: '{src}'. Index name allows only alphanumeric characters, '-' and '_'."
+
+        if src_lower == "kvstore":
+            return "Invalid index name: cannot use reserved name 'kvstore' as an index name."
+
+        return ""
+
+    @staticmethod
+    def _validate_as_dataset_name(inner_name: str) -> str:
+        if not inner_name:
+            return "MDL federated dataset name is required"
+
+        if len(inner_name) >= IndexName._DATASET_NAME_MAX_LEN:
+            return "MDL federated dataset name must be less than 1024 characters."
+
+        if "." in inner_name:
+            return "MDL federated dataset name cannot contain '.'"
+
+        if inner_name.lower() == "default":
+            return "Invalid MDL federated dataset name: 'default' is reserved"
+
+        return ""
+
+    @staticmethod
+    def validate_fallback(name: str) -> str:
+        """
+        Returns an error string, or empty string when valid. Mirrors
+        IndexAdminHandler::validateName() routing to either
+        _validate_as_dataset_name or _validate_as_index_name.
+        """
+        if name.startswith(IndexName._FEDERATED_MDL_PREFIX):
+            inner = name[len(IndexName._FEDERATED_MDL_PREFIX) :]
+            return IndexName._validate_as_dataset_name(inner)
+        return IndexName._validate_as_index_name(name)
+
+    @staticmethod
+    def _get_session_key():
+        import __main__
+
+        return getattr(__main__, "___sessionKey", None)
+
+    @staticmethod
+    def _get_splunkd_info():
+        import urllib.parse
+
+        from solnlib.splunkenv import get_splunkd_uri
+
+        splunkd_uri = os.environ.get("SPLUNKD_URI") or get_splunkd_uri()
+        return urllib.parse.urlparse(splunkd_uri)
+
+    @staticmethod
+    def _extract_http_error_message(exc):
+        try:
+            return json.loads(exc.body)["messages"][0]["text"]
+        except (IndexError, KeyError, TypeError, ValueError):
+            return None
+
+    def _call_validate_endpoint(self, value):
+        """
+        Returns (result, error_message) where:
+          result=None  — endpoint not present or session key unavailable; caller falls back to local rules
+          result=True  — name is valid
+          result=False — name is invalid or request failed; error_message contains the reason
+        """
+        from solnlib.splunk_rest_client import SplunkRestClient
+        from splunklib import binding
+
+        from ..util import get_base_app_name
+
+        from splunktaucclib.common import log as ucclog
+
+        session_key = self._get_session_key()
+        if not session_key:
+            ucclog.logger.error(
+                "IndexName: session key not available, cannot call _validateName endpoint"
+            )
+            return None, None
+
+        splunkd_info = self._get_splunkd_info()
+        client = SplunkRestClient(
+            session_key,
+            get_base_app_name(),
+            scheme=splunkd_info.scheme,
+            host=splunkd_info.hostname,
+            port=splunkd_info.port,
+        )
+        try:
+            response = client.post(
+                self._ENDPOINT,
+                output_mode="json",
+                body={"index_name": value},
+            )
+        except binding.HTTPError as exc:
+            if exc.status == 404:
+                ucclog.logger.warning(
+                    "IndexName: indexes endpoint not found (HTTP 404), no custom validation action _validateName supported, falling back to local validation"
+                )
+                return None, None
+
+            error_message = self._extract_http_error_message(exc)
+            if exc.status == 400:
+                if error_message == self._MSG_INDEX_NAME_NOT_SUPPORTED:
+                    ucclog.logger.warning(
+                        "IndexName: indexes endpoint does not have custom validation action _validateName supported (HTTP 400), falling back to local validation"
+                    )
+                    return None, None
+
+            if exc.status == 403:
+                ucclog.logger.warning(
+                    "IndexName: insufficient permissions to call _validateName endpoint (HTTP 403)"
+                )
+                return False, "Insufficient permissions to validate index name"
+
+            ucclog.logger.warning(
+                "IndexName: _validateName endpoint returned HTTP %s: %s",
+                exc.status,
+                error_message or exc.body,
+            )
+            return (
+                False,
+                f"Index name validation request failed: HTTP {exc.status}, {error_message or exc.body}",
+            )
+        except Exception as exc:
+            ucclog.logger.error(
+                "IndexName: unexpected error calling _validateName endpoint: %s",
+                exc,
+            )
+            return (
+                False,
+                f"Index name validation request failed, unexpected error: {exc}",
+            )
+
+        try:
+            response_body = response.body.read()
+            content = json.loads(response_body)["entry"][0]["content"]
+            if content["is_valid"] == "true":
+                return True, None
+            return False, content.get("reason", "Invalid index name")
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            ucclog.logger.error(
+                f"Unexpected response from validation endpoint: response {response_body}, error {exc}"
+            )
+            return None, None
+
+    def validate(self, value, data):
+        from splunktaucclib.common import log as ucclog
+
+        self._msg = ""
+        result, error = self._call_validate_endpoint(value)
+
+        if result is None:
+            # endpoint not available — fall back to local rules
+            error = self.validate_fallback(value)
+            if error:
+                ucclog.logger.debug(
+                    "IndexName: local validation rejected '%s': %s", value, error
+                )
+                self.put_msg(error)
+            return not bool(error)
+
+        if not result:
+            self.put_msg(error)
+        return result

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,17 @@
 import os
+import sys
+import types
 from unittest.mock import MagicMock
 
 import pytest
+
+# Stub solnlib.log before any splunktaucclib module imports it, so that
+# splunktaucclib.common.log can be imported outside a Splunk process.
+_mock_logs_instance = MagicMock()
+_mock_logs_instance.get_logger.return_value = MagicMock()
+_solnlib_log_stub = types.ModuleType("solnlib.log")
+_solnlib_log_stub.Logs = MagicMock(return_value=_mock_logs_instance)
+sys.modules.setdefault("solnlib.log", _solnlib_log_stub)
 
 from tests.unit.fake_module import mock_splunk_module
 

--- a/tests/unit/test_rest_handler_validators.py
+++ b/tests/unit/test_rest_handler_validators.py
@@ -1,0 +1,549 @@
+#
+# Copyright 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from splunktaucclib.rest_handler.endpoint.validator import IndexName
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(is_valid: bool, reason: str = "") -> MagicMock:
+    """Build a fake splunklib response for the _validateName endpoint."""
+    content = {"is_valid": "true" if is_valid else "false", "name": "test"}
+    if not is_valid:
+        content["reason"] = reason
+    body = json.dumps({"entry": [{"content": content}]}).encode()
+    response = MagicMock()
+    response.body.read.return_value = body
+    return response
+
+
+def _http_error(status: int, body: bytes = b"<error/>") -> Exception:
+    """Build a fake splunklib HTTPError with the given status code."""
+    from splunklib import binding
+
+    response = MagicMock()
+    response.status = status
+    response.reason = "reason"
+    response.body.read.return_value = body
+    err = binding.HTTPError(response, body)
+    err.status = status
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def patch_env(monkeypatch):
+    monkeypatch.setitem(os.environ, "SPLUNKD_URI", "https://localhost:8089")
+
+
+@pytest.fixture
+def validator():
+    return IndexName()
+
+
+@pytest.fixture
+def mock_ucclog(monkeypatch):
+    from splunktaucclib.common import log as ucclog
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr(ucclog, "logger", mock_logger)
+    return mock_logger
+
+
+# ---------------------------------------------------------------------------
+# validate_fallback — local rules
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFallback:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "main",
+            "index42",
+            "my-index_01",
+            "MAIN",  # uppercase allowed per CharacterClass::ALPHA_NUM_UNDER_DASH
+            "My-Index",  # mixed case
+            "a" * 2048,  # exactly at max length
+            "federated:my_dataset",  # valid name with optional prefix
+            "_internal",
+            "_audit",
+            "_thefishbucket",
+            "_telemetry",
+            "_metrics",
+            "_introspection",
+            "_configtracker",
+            "_dsphonehome",
+            "_dsappevent",
+            "_dsclient",
+            "_cmc_summary",
+            "_metrics_rollup",
+            "_dm_summary",
+            "_dsevent_index_summary",
+            "help",
+            "history",
+            "sample",
+            "splunklogger",
+            "summary",
+            "~.federated.my_dataset",  # valid MDL dataset name
+            "~.federated." + "x" * 1023,  # dataset name 1023 chars — ok (< 1024)
+            "_INTERNAL",  # uppercase — src_lower matches _internal in allowed set
+            "_AUDIT",  # uppercase — src_lower matches _audit in allowed set
+        ],
+    )
+    def test_valid_names(self, name):
+        assert IndexName.validate_fallback(name) == ""
+
+    @pytest.mark.parametrize(
+        "name,reason_contains",
+        [
+            ("a" * 2049, "too long"),
+            ("-bad", "cannot start with"),
+            ("_custom", "cannot start with"),
+            ("bad name!", "alphanumeric"),
+            ("Bad Name", "alphanumeric"),  # space not in valid char set
+            ("~.federated.", "required"),  # empty inner name after MDL prefix strip
+            ("~.my_index", "alphanumeric"),  # ~ not in valid char set
+            ("())())))))((", "alphanumeric"),
+            ("kvstore", "kvstore"),
+            ("KVSTORE", "kvstore"),  # case-insensitive reserved word check
+            ("federated:KVSTORE", "kvstore"),  # case-insensitive after prefix strip
+            ("federated:-bad", "cannot start with"),  # hyphen after prefix strip
+            ("", "empty"),
+            ("federated:", "empty"),  # empty name after prefix strip
+            ("~.federated.my.dataset", "cannot contain"),  # dot in dataset name
+            ("~.federated.default", "default"),  # reserved dataset name
+            (
+                "~.federated.DEFAULT",
+                "default",
+            ),  # reserved dataset name — case-insensitive
+            ("~.federated.Default", "default"),  # reserved dataset name — mixed case
+            ("~.federated." + "x" * 1024, "1024"),  # dataset name >= 1024 chars
+        ],
+    )
+    def test_invalid_names(self, name, reason_contains):
+        reason = IndexName.validate_fallback(name)
+        assert reason != ""
+        assert reason_contains in reason
+
+
+# ---------------------------------------------------------------------------
+# _get_session_key — reads __main__.___sessionKey
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionKey:
+    def test_returns_session_key_when_set(self, monkeypatch):
+        import __main__
+
+        monkeypatch.setattr(__main__, "___sessionKey", "abc123", raising=False)
+        assert IndexName._get_session_key() == "abc123"
+
+    def test_returns_none_when_attribute_absent(self, monkeypatch):
+        import __main__
+
+        monkeypatch.delattr(__main__, "___sessionKey", raising=False)
+        assert IndexName._get_session_key() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_splunkd_info — env var vs solnlib fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGetSplunkdInfo:
+    def test_uses_splunkd_uri_env_var(self, monkeypatch):
+        monkeypatch.setitem(os.environ, "SPLUNKD_URI", "https://myhost:9089")
+        info = IndexName._get_splunkd_info()
+        assert info.hostname == "myhost"
+        assert info.port == 9089
+        assert info.scheme == "https"
+
+    def test_falls_back_to_get_splunkd_uri_when_env_absent(self, monkeypatch):
+        monkeypatch.delitem(os.environ, "SPLUNKD_URI", raising=False)
+        monkeypatch.setattr(
+            "solnlib.splunkenv.get_splunkd_uri",
+            lambda: "https://fallback:8089",
+        )
+        info = IndexName._get_splunkd_info()
+        assert info.hostname == "fallback"
+        assert info.port == 8089
+
+
+# ---------------------------------------------------------------------------
+# _call_validate_endpoint — HTTP interaction
+# ---------------------------------------------------------------------------
+
+
+class TestCallValidateEndpoint:
+    _SESSION_KEY = "session_key"
+    _APP_NAME = "test_app"
+
+    def _splunkd_info(self):
+        import urllib.parse
+
+        return urllib.parse.urlparse("https://localhost:8089")
+
+    def _make_validator_with_client(self, monkeypatch, client):
+        self._rest_client_cls = MagicMock(return_value=client)
+        monkeypatch.setattr(
+            "solnlib.splunk_rest_client.SplunkRestClient",
+            self._rest_client_cls,
+        )
+        monkeypatch.setattr(
+            "splunktaucclib.rest_handler.util.get_base_app_name",
+            lambda: self._APP_NAME,
+        )
+        monkeypatch.setattr(
+            IndexName, "_get_session_key", staticmethod(lambda: self._SESSION_KEY)
+        )
+        monkeypatch.setattr(
+            IndexName,
+            "_get_splunkd_info",
+            staticmethod(lambda: self._splunkd_info()),
+        )
+        return IndexName()
+
+    def test_valid_name_returns_true(self, monkeypatch):
+        client = MagicMock()
+        client.post.return_value = _make_response(True)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is True
+        assert error is None
+
+    def test_post_called_with_correct_endpoint_and_body(self, monkeypatch):
+        client = MagicMock()
+        client.post.return_value = _make_response(True)
+        v = self._make_validator_with_client(monkeypatch, client)
+        v._call_validate_endpoint("main")
+        client.post.assert_called_once_with(
+            IndexName._ENDPOINT,
+            output_mode="json",
+            body={"index_name": "main"},
+        )
+
+    def test_splunk_rest_client_constructed_with_correct_args(self, monkeypatch):
+        client = MagicMock()
+        client.post.return_value = _make_response(True)
+        v = self._make_validator_with_client(monkeypatch, client)
+        splunkd_info = self._splunkd_info()
+        v._call_validate_endpoint("main")
+        self._rest_client_cls.assert_called_once_with(
+            self._SESSION_KEY,
+            self._APP_NAME,
+            scheme=splunkd_info.scheme,
+            host=splunkd_info.hostname,
+            port=splunkd_info.port,
+        )
+
+    def test_invalid_name_returns_false_with_reason(self, monkeypatch):
+        client = MagicMock()
+        client.post.return_value = _make_response(
+            False, "Name contains invalid characters"
+        )
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("bad:name")
+        assert result is False
+        assert error == "Name contains invalid characters"
+
+    def test_invalid_name_missing_reason_uses_default(self, monkeypatch):
+        client = MagicMock()
+        body = json.dumps(
+            {"entry": [{"content": {"is_valid": "false", "name": "x"}}]}
+        ).encode()
+        resp = MagicMock()
+        resp.body.read.return_value = body
+        client.post.return_value = resp
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("x")
+        assert result is False
+        assert error == "Invalid index name"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b"not json at all",
+            json.dumps({"entry": []}).encode(),
+            json.dumps({"entry": [{}]}).encode(),
+            json.dumps({}).encode(),
+            json.dumps(
+                {"entry": [{"content": None}]}
+            ).encode(),  # content: null → TypeError
+        ],
+    )
+    def test_malformed_response_returns_none_for_fallback(
+        self, monkeypatch, body, mock_ucclog
+    ):
+        client = MagicMock()
+        resp = MagicMock()
+        resp.body.read.return_value = body
+        client.post.return_value = resp
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is None
+        assert error is None
+        mock_ucclog.error.assert_called_once()
+        assert "Unexpected response" in mock_ucclog.error.call_args[0][0]
+
+    def test_404_returns_none_for_fallback(self, monkeypatch, mock_ucclog):
+        client = MagicMock()
+        client.post.side_effect = _http_error(404)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is None
+        assert error is None
+        mock_ucclog.warning.assert_called_once()
+        assert "404" in mock_ucclog.warning.call_args[0][0]
+
+    def test_403_returns_false_with_permissions_message(self, monkeypatch, mock_ucclog):
+        client = MagicMock()
+        client.post.side_effect = _http_error(403)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "permissions" in error.lower()
+        mock_ucclog.warning.assert_called_once()
+        assert "403" in mock_ucclog.warning.call_args[0][0]
+
+    def test_500_returns_false_with_status_in_message(self, monkeypatch, mock_ucclog):
+        client = MagicMock()
+        client.post.side_effect = _http_error(500)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "500" in error
+        mock_ucclog.warning.assert_called_once()
+        assert "500" in str(mock_ucclog.warning.call_args)
+
+    def test_400_index_name_not_supported_returns_none_for_fallback(
+        self, monkeypatch, mock_ucclog
+    ):
+        body = json.dumps(
+            {
+                "messages": [
+                    {"type": "ERROR", "text": IndexName._MSG_INDEX_NAME_NOT_SUPPORTED}
+                ]
+            }
+        ).encode()
+        client = MagicMock()
+        client.post.side_effect = _http_error(400, body)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is None
+        assert error is None
+        mock_ucclog.warning.assert_called_once()
+        assert "400" in mock_ucclog.warning.call_args[0][0]
+
+    def test_400_empty_messages_list_returns_false_with_status(
+        self, monkeypatch, mock_ucclog
+    ):
+        body = json.dumps({"messages": []}).encode()
+        client = MagicMock()
+        client.post.side_effect = _http_error(400, body)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "400" in error
+
+    def test_400_null_messages_returns_false_with_status(
+        self, monkeypatch, mock_ucclog
+    ):
+        body = json.dumps({"messages": None}).encode()
+        client = MagicMock()
+        client.post.side_effect = _http_error(400, body)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "400" in error
+
+    def test_400_other_message_returns_false_with_status(
+        self, monkeypatch, mock_ucclog
+    ):
+        body = json.dumps(
+            {"messages": [{"type": "ERROR", "text": "Some other bad request error"}]}
+        ).encode()
+        client = MagicMock()
+        client.post.side_effect = _http_error(400, body)
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "400" in error
+        mock_ucclog.warning.assert_called_once()
+        assert "400" in str(mock_ucclog.warning.call_args)
+
+    def test_unexpected_exception_returns_false_with_message(
+        self, monkeypatch, mock_ucclog
+    ):
+        client = MagicMock()
+        client.post.side_effect = RuntimeError("connection refused")
+        v = self._make_validator_with_client(monkeypatch, client)
+        result, error = v._call_validate_endpoint("main")
+        assert result is False
+        assert "connection refused" in error
+        mock_ucclog.error.assert_called_once()
+        assert "connection refused" in str(mock_ucclog.error.call_args)
+
+    def test_no_session_key_returns_none_for_fallback(self, monkeypatch, mock_ucclog):
+        monkeypatch.setattr(IndexName, "_get_session_key", staticmethod(lambda: None))
+        mock_splunkd = MagicMock()
+        monkeypatch.setattr(IndexName, "_get_splunkd_info", staticmethod(mock_splunkd))
+        result, error = IndexName()._call_validate_endpoint("main")
+        assert result is None
+        assert error is None
+        mock_ucclog.error.assert_called_once()
+        assert "session key" in mock_ucclog.error.call_args[0][0]
+
+    def test_splunkd_info_not_called_when_no_session_key(self, monkeypatch):
+        monkeypatch.setattr(IndexName, "_get_session_key", staticmethod(lambda: None))
+        mock_splunkd = MagicMock()
+        monkeypatch.setattr(IndexName, "_get_splunkd_info", staticmethod(mock_splunkd))
+        IndexName()._call_validate_endpoint("main")
+        mock_splunkd.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# validate — full orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    @pytest.fixture
+    def patched_validator(self, monkeypatch):
+        import urllib.parse
+
+        monkeypatch.setattr(
+            IndexName, "_get_session_key", staticmethod(lambda: "fake_key")
+        )
+        monkeypatch.setattr(
+            IndexName,
+            "_get_splunkd_info",
+            staticmethod(lambda: urllib.parse.urlparse("https://localhost:8089")),
+        )
+        return IndexName()
+
+    def test_no_session_key_falls_back_to_local_rules(self, monkeypatch):
+        monkeypatch.setattr(IndexName, "_get_session_key", staticmethod(lambda: None))
+        v = IndexName()
+        assert v.validate("main", {}) is True
+        assert v.validate("kvstore", {}) is False
+        assert "kvstore" in v.msg
+
+    def test_validate_endpoint_called_with_value(self, patched_validator, monkeypatch):
+        mock_endpoint = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(patched_validator, "_call_validate_endpoint", mock_endpoint)
+        patched_validator.validate("main", {})
+        mock_endpoint.assert_called_once_with("main")
+
+    def test_valid_name_via_endpoint(self, patched_validator, monkeypatch):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(True, None)),
+        )
+        assert patched_validator.validate("main", {}) is True
+
+    def test_invalid_name_via_endpoint_sets_msg(self, patched_validator, monkeypatch):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(False, "Name is reserved")),
+        )
+        assert patched_validator.validate("kvstore", {}) is False
+        assert patched_validator.msg == "Name is reserved"
+
+    def test_fallback_called_when_endpoint_unavailable(
+        self, patched_validator, monkeypatch
+    ):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(None, None)),
+        )
+        mock_fallback = MagicMock(return_value="")
+        monkeypatch.setattr(IndexName, "validate_fallback", staticmethod(mock_fallback))
+        patched_validator.validate("main", {})
+        mock_fallback.assert_called_once_with("main")
+
+    def test_fallback_valid_when_endpoint_unavailable(
+        self, patched_validator, monkeypatch
+    ):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(None, None)),
+        )
+        assert patched_validator.validate("main", {}) is True
+
+    @pytest.mark.parametrize(
+        "name,reason_contains",
+        [
+            ("a" * 2049, "too long"),
+            ("-bad", "cannot start with"),
+            ("_custom", "cannot start with"),
+            ("bad name!", "alphanumeric"),
+            ("Bad Name", "alphanumeric"),
+            ("~.federated.", "required"),
+            ("~.my_index", "alphanumeric"),
+            ("())())))))((", "alphanumeric"),
+            ("kvstore", "kvstore"),
+            ("KVSTORE", "kvstore"),
+            ("federated:KVSTORE", "kvstore"),
+            ("federated:-bad", "cannot start with"),
+            ("", "empty"),
+            ("federated:", "empty"),
+            ("~.federated.my.dataset", "cannot contain"),
+            ("~.federated.default", "default"),
+            (
+                "~.federated.DEFAULT",
+                "default",
+            ),  # reserved dataset name — case-insensitive
+            ("~.federated." + "x" * 1024, "1024"),  # dataset name >= 1024 chars
+        ],
+    )
+    def test_fallback_invalid_when_endpoint_unavailable(
+        self, patched_validator, monkeypatch, name, reason_contains
+    ):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(None, None)),
+        )
+        assert patched_validator.validate(name, {}) is False
+        assert reason_contains in patched_validator.msg
+
+    def test_endpoint_error_returns_false_with_msg(
+        self, patched_validator, monkeypatch
+    ):
+        monkeypatch.setattr(
+            patched_validator,
+            "_call_validate_endpoint",
+            MagicMock(return_value=(False, "HTTP 500")),
+        )
+        assert patched_validator.validate("main", {}) is False
+        assert patched_validator.msg == "HTTP 500"


### PR DESCRIPTION
## Why

This PR is part of a multilayer change to replace current per-add-on length and regex index name validators with a central, authoritative validation endpoint. The new validation also covers MDL (Machine Data Lake) federated dataset names — `~.federated.<name>` — which route data to Machine Data Lake via Ingest Processor and have naming rules that a single regex cannot handle correctly.

The changes:
- **SplCore** — implements `POST /services/data/indexes/_validateName` as the single point of truth for index name validation. All future rule changes happen here only, without requiring updates across individual add-ons.
- **splunktaucclib (this PR)** — adds `IndexName` validator that calls the SplCore endpoint. Falls back to a local reimplementation of the same rules to stay compatible with older Splunk versions where the endpoint is not yet available.
- **splunk-add-on-ucc-framework** — adds `{"type": "index_name"}` support to `globalConfig.json` schema and generates `validator.IndexName()` in REST handler code. Most add-ons have no custom REST handler and rely entirely on ucc-gen; without this change they would need to add a custom handler just to use the new validator.
- **Technology add-ons** — replace current length and regex validators in `globalConfig.json` with `{"type": "index_name"}`. Add-ons with existing custom validators replace those with `IndexName` directly.

## What

Adds a new `IndexName` validator class to `splunktaucclib/rest_handler/endpoint/validator.py`.

## How

- Calls `POST /services/data/indexes/_validateName` (Splunk core endpoint) to validate a candidate index name without creating anything.
- Session key is auto-detected from `__main__.___sessionKey` (written by `MConfigHandler.__init__` from stdin before any handler method runs).
- splunkd URI is auto-detected from the `SPLUNKD_URI` environment variable, falling back to `solnlib.splunkenv.get_splunkd_uri()`.
- Falls back to local pure-Python validation rules (mirroring `IndexAdminHandler::validateName()` from splcore develop branch) when the endpoint is unavailable: HTTP 404 (older Splunk versions), HTTP 400 with unsupported `index_name` argument, or no session key available.
- `_call_validate_endpoint` returns `(None, None)` to signal fallback, `(True, None)` for valid, `(False, str)` for invalid or request failure.
- `validate_fallback` and helpers (`_validate_as_index_name`, `_validate_as_dataset_name`) return a plain `str` — empty means valid, non-empty is the error message.
- Handles three name shapes: regular index names, `federated:` prefix (stripped before applying index rules), and `~.federated.` MDL dataset names (routed to dataset-specific validation).
- `ucclog` logging throughout `_call_validate_endpoint` (WARNING for 404/400/403/5xx, ERROR for unexpected exceptions and malformed responses) and `validate()` (DEBUG for local fallback rejections).
- `self._msg` cleared at the start of `validate()` to prevent stale error messages when the validator instance is reused across requests.
- Lazy import of `ucclog` inside methods to avoid `solnlib.log.Logs()` being called at import time (requires Splunk runtime).
- Endpoint response parsing and HTTP error message extraction both wrapped defensively: `except (KeyError, IndexError, TypeError, ValueError)` covers missing keys, empty/null lists, null content, and non-JSON bodies.
- Zero-argument constructor — works as a drop-in `RestField` validator at class definition time, consistent with all existing validators.
- `_INTERNAL_INDEXES` frozenset sourced from splcore develop branch `IndexAdminHandler::validateName()`.

## Usage

```python
RestField("index", required=True, validator=IndexName())
```

## Tests

98 unit tests across five test classes:

- `TestValidateFallback` — parametrized valid/invalid name cases for local rules, covering regular names, `federated:` prefix, `~.federated.` MDL dataset names, case-insensitive `kvstore` and `default` checks, length boundaries, and all reserved internal index names.
- `TestGetSessionKey` — reads `__main__.___sessionKey`; absent attribute returns `None`.
- `TestGetSplunkdInfo` — `SPLUNKD_URI` env var parsing; solnlib fallback when env var absent.
- `TestCallValidateEndpoint` — HTTP interaction: correct `client.post()` endpoint/body, correct `SplunkRestClient` constructor args, 404/403/400/5xx handling with log assertions, malformed response shapes (non-JSON, empty entry list, missing content key, `content: null`, `messages: null`, empty `messages` list), no session key path.
- `TestValidate` — orchestration: endpoint called with correct value, fallback triggered on `(None, None)`, `self.msg` set correctly on failure, no-session-key falls back to local rules.